### PR TITLE
Image-model picker, multi-pose on-model, native aspect re-render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI (lint, unit, types)
+
+on:
+  pull_request:
+    branches: [staging, main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    env:
+      # prisma.config.ts resolves DIRECT_URL at load time; `prisma generate`
+      # (postinstall) never connects, so a placeholder satisfies it in CI.
+      DIRECT_URL: "postgresql://placeholder:placeholder@localhost:5432/placeholder"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Unit tests
+        run: npm test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,87 @@
+name: E2E (real generation)
+
+# Paid pipeline verification: spins up next dev + a Trigger dev worker inside
+# the runner and generates one real creative per kind (in-scene campaign +
+# on-model plain) in the "E2E Tests" workspace, on the cheap-model lineup.
+# Runs on feature PRs into staging (the owner pushes small fixes straight to
+# main, skipping this cost — see repo branch rules) and on demand.
+on:
+  pull_request:
+    branches: [staging]
+  workflow_dispatch:
+
+# One generation suite at a time — parallel suites would race the shared
+# Trigger dev environment and the E2E workspace credits.
+concurrency:
+  group: e2e-real-generation
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+      AUTH_URL: http://localhost:6969
+      AUTH_TRUST_HOST: "1"
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      RUNWARE_API_KEY: ${{ secrets.RUNWARE_API_KEY }}
+      # Dev-env key: generations enqueue to the Trigger DEV environment and are
+      # executed by the worker started below, so the cheap-model env applies.
+      TRIGGER_SECRET_KEY: ${{ secrets.TRIGGER_DEV_SECRET_KEY }}
+      TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+      SUPER_ADMIN_EMAIL: ${{ secrets.SUPER_ADMIN_EMAIL }}
+      DEV_AUTH_BYPASS: "1"
+      E2E_REAL_GENERATION: "1"
+      # Cheap-model lineup: full pipeline shape, minimum spend. Slots documented
+      # in src/lib/ai/models.ts; image hero slot pinned to Nano Banana 2 and the
+      # provider forced to gemini (no premium fallback chain).
+      MODEL_CONCEPTS: claude-haiku-4-5-20251001
+      MODEL_BRIEF_QA: claude-haiku-4-5-20251001
+      MODEL_RESEARCH: claude-haiku-4-5-20251001
+      GEMINI_IMAGE_MODEL: gemini-3.1-flash-image
+      IMAGE_PROVIDER: gemini
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Trigger dev worker
+        # Pinned to the exact CLI version in package.json (mismatch aborts).
+        # Headless auth via TRIGGER_ACCESS_TOKEN. The worker keeps running for
+        # the whole job; runs enqueued before it connects wait in the dev queue.
+        run: |
+          npx trigger.dev@4.5.0 dev --log-level info > trigger-dev.log 2>&1 &
+          echo $! > trigger-dev.pid
+          sleep 20
+          grep -qi "error" trigger-dev.log && cat trigger-dev.log || true
+
+      - name: Run e2e suite
+        run: npx playwright test
+
+      - name: Trigger worker log (on failure)
+        if: failure()
+        run: tail -100 trigger-dev.log || true
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ graphify-out/
 # playwright
 /test-results/
 /playwright-report/
+
+# Playwright MCP browser cache
+.playwright-mcp/

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -67,7 +67,105 @@ New entries go at the **top** of the Log section (reverse chronological).
 
 ## Log
 
-### 2026-07-22 — USD cost removed from the product UI entirely (no super-admin exception); /admin/costs is the only cost surface
+### 2026-07-22 — Super-admin workspace image-model picker (7 models incl. cheap Chinese Runware models)
+
+- Type: feature
+- Scope: prisma/schema.prisma (Workspace.imageModel), src/lib/image/{provider.ts,runware.ts}, src/trigger/generation-run.ts, src/app/actions/workspace.ts, src/app/(app)/settings/{page.tsx,settings-client.tsx}
+
+Reasoning / RCA / research:
+    - Owner wants to A/B image models per workspace to save cost — simple e-commerce apparel doesn't need the premium tier. The create-form model picker was removed earlier (dev-only), so the knob belongs at the workspace level, visible/settable by the platform super-admin only.
+    - Added Qwen-Image (runware:108@1) and Wan 2.7 (alibaba:wan@2.7-image) — cheap Alibaba models that both accept reference images (garment/product fidelity survives). Verified the exact Runware AIR ids via Runware docs; "Wan 2.2" was resolved to the current 2.7 image model.
+    - Kept it a SOFT preference: the chosen model leads but the full quality-first cascade stays behind it, so a paid run survives a model outage. A hard pin would fail the run when the cheap model hiccups.
+    - Threaded a `runwareModel` down ChainStep/BakeoffVariant/SceneGenParams so one "seedream" provider can front several Runware models. Critical subtlety (unit-tested): a fallback seedream step must NOT inherit the leading pick's model key — runProvider now reads the STEP's model, not the top-level param.
+
+Implementation summary:
+    - WORKSPACE_IMAGE_MODELS registry + resolveWorkspaceImageModel() in provider.ts; generation-run resolves it ahead of the legacy per-run pref. setWorkspaceImageModel action gated on isSuperAdmin. Settings picker rendered only for super-admins (model list passed as plain props so provider.ts/sharp never bundles into the client).
+    - 4 new provider unit tests (registry integrity + fallback model isolation). Migration 20260722133655.
+
+### 2026-07-22 — Multi-pose on-model: same model + garment, one image per selected pose in a single run
+
+- Type: feature
+- Scope: prisma/schema.prisma (GenerationRun.modelPoses), src/app/(app)/studio/create-form.tsx, src/app/actions/generate.ts, src/trigger/generation-run.ts
+
+Reasoning / RCA / research:
+    - Owner wants pose variety for apparel: pick several poses, get the SAME model in the SAME garment across them. Previously on-model with N options generated N different CONCEPTS (different scenes) — wrong axis of variation.
+    - Decision (grilled): poses REPLACE the option count for on-model. M selected poses → M images; the "how many options" picker is hidden for on-model. Empty selection = one AI-varied pose (legacy behavior preserved).
+    - Implementation: generate ONE concept, then fan out one work item per pose (poseOverride threaded into ConceptCtx → buildOnModelPrompt). The pose is stored in the creative's concept JSON so an editor aspect re-render reproduces it.
+    - modelPoses sent as a JSON array (pose text contains commas; a delimiter join is unsafe), parsed + capped server-side; conceptCount for on-model = pose count.
+
+Implementation summary:
+    - create-form pose pills became multi-select + a custom-pose field appended to the set; cost/summary/CTA driven by the pose count. generate.ts derives conceptCount and stores modelPoses. Migration shared with the image-model change.
+
+### 2026-07-22 — Editor "add format" now renders a NATIVE plate per ratio (no more crop) and charges credits
+
+- Type: bug
+- Scope: src/lib/editor/paid-edits.ts (applyRenderAspect), src/app/actions/editor.ts, src/trigger/creative-edit.ts, src/app/(app)/library/[creativeId]/{preview-stage.tsx,editor.tsx}
+
+Reasoning / RCA / research:
+    - Symptom (owner): switching a creative to another format in the editor "just crops the photo rather than fitting the dimension", 4:5 looked cut. RCA: generation already renders a native plate per requested aspect, but the editor's "add format" (applyRenderAspect) cover-cropped the master plate into the new ratio — a big crop that clips heads/feet. Confirmed Nano Banana natively supports 4:5, so the generation side was fine; the crop was purely the editor path.
+    - Fix (owner-chosen): re-generate a native plate for the new ratio via the image model, reusing the run's references (cutout-preferred) + the same prompt builder (buildOnModelPrompt / buildScenePassPrompt) + the workspace image-model setting. Reconstructing the run context (product/model/pose/fidelity) is what makes the re-render faithful rather than a generic redraw.
+    - Owner chose to CHARGE credits (it's a real image generation). Collapsed the old render_aspect "free" special-case: startCreativeEdit now debits every edit kind, applyRenderAspect refunds on handled failure, and the task's catchError refunds render_aspect on crash (previously it skipped it). The native plate is also saved as that aspect's own plate key so later text/language edits recomposite from it, not a crop.
+
+Implementation summary:
+    - applyRenderAspect rewritten (native render + cost tracking + aspectPlateKeys update). Editor "add format" badge changed from "Free" to the credit cost. Pose persisted in concept JSON at generation so re-renders match.
+
+- Type: bug
+- Scope: src/app/(app)/layout.tsx
+
+Reasoning / RCA / research:
+    - Symptom: click Generate → blank "Something went wrong" page, yet the run showed RUNNING in the library and actually COMPLETED. Third distinct failure in this flow (after the preview-key enqueue bug and the Node-21 WebSocket worker crash) — each a different layer.
+    - Vercel error log pinned it: `POST /studio — Vercel Runtime Timeout Error: Task timed out after 10 seconds`. startGenerationRun does auth + ~8 sequential Supabase round-trips + a Trigger enqueue; a cold invocation crosses 10s. The enqueue had already succeeded, so the pipeline ran while the browser got the crash page.
+    - Status codes were all 200 in the request logs — RSC/server-action errors don't surface as 5xx, so `--level error` (not `--status-code 5xx`) was the query that found it.
+    - Fix at the layout, not per page: server actions POST to the page hosting the form, and Next segment config cascades from layouts (verified in next.js reduceAppConfig), so one `export const maxDuration = 60` in src/app/(app)/layout.tsx covers every app action. All genuinely slow work already lives in Trigger tasks; nothing needs more than 60s.
+    - The bare unstyled crash page is global-error.tsx (the app has no nested error.tsx) — deliberately left for a future polish pass; the timeout fix removes the trigger.
+
+Implementation summary:
+    - One segment-config export + comment; verified layout-level cascade against Next.js docs/source before relying on it.
+
+### 2026-07-22 — Product-image background removal moved to upload time: cached cutouts, reused as generation references
+
+- Type: feature
+- Scope: prisma/schema.prisma (+migration 20260722115500), src/lib/storage.ts, src/lib/image/runware.ts, src/trigger/product-cutout.ts (new), src/app/actions/products.ts, src/trigger/generation-run.ts, src/lib/pipeline/cost-log.ts
+
+Reasoning / RCA / research:
+    - Owner ask: "remove bg once and reuse". Audit found NO bg removal anywhere in the pipeline today (cut-out paste was retired for premium in-scene), so this is a new capability, not an optimisation: raw product photos were going to image models as references, busy backgrounds and all.
+    - One-time per image at upload (product-cutout task) beats per-run removal: paid once (~$0.004/image via Runware removeBackground, runware:109@1), cached forever in cutoutKey.
+    - Cutouts are flattened onto white with sharp instead of shipping alpha: image models handle a clean studio packshot better than transparency, and it matches the e-comm listing look. Flattening locally (not Runware settings.rgba) keeps the behavior model-independent.
+    - Generation prefers cutoutKey and falls back to the original photo when absent — a failed/missing cutout can never fail a paid run; the task is idempotent (only processes cutoutKey=null rows) so re-triggering is free.
+
+Implementation summary:
+    - ProductImage.cutoutKey (nullable) + removeBackground() in runware.ts (includeCost, retry-wrapped) + product-cutout task; triggered from createProduct, createProductInline, addProductImages.
+    - generation-run: ConceptCtx gained refMime; primary + extra refs use cutout when present (mimeType then image/png).
+    - Cost rows land in ApiCostLog under new source "cutout".
+
+Follow-ups deferred:
+    - Backfill for pre-existing product images (task triggers only on upload); trivial script when wanted.
+    - AI-model photos not cutout — they're already studio shots.
+
+### 2026-07-22 — Real-generation e2e (browser → live pipeline on cheap models) + staging branch flow with CI gates
+
+- Type: build
+- Scope: e2e/generation.spec.ts (new), scripts/seed-e2e-workspace.ts (new), .github/workflows/{ci.yml,e2e.yml} (new), GitHub branch protection (main, staging), 11 Actions secrets
+
+Reasoning / RCA / research:
+    - Chosen shape (owner-grilled): Playwright vs localhost with DEV_AUTH_BYPASS + a Trigger DEV worker inside the CI runner. Because the worker runs in-job, cheap-model env vars apply (MODEL_CONCEPTS/BRIEF_QA/RESEARCH=haiku, GEMINI_IMAGE_MODEL=NB2, IMAGE_PROVIDER=gemini forced) — the same runs against the prod Trigger deployment would use full-price models since env lives with the deployment. Hence the DEV TRIGGER_SECRET_KEY in CI, never the prod one.
+    - Dedicated "E2E Tests" workspace (slug e2e-tests, id a15a9e76-…) seeded by cloning Blueman brand + one dissected apparel product + 10k credits from Synerix Apparel — rows only, storage keys shared. Spec pins it via sx-active-ws cookie; ws id is hardcoded (E2E_WORKSPACE_ID overridable) because Playwright's transpiler can't resolve the "@/" alias inside src/lib/db.ts (first run failed exactly there).
+    - Paid spec is opt-in (E2E_REAL_GENERATION=1) so `npm run test:e2e` stays free locally; serial mode + workflow concurrency group because parallel suites would race the shared Trigger dev env and credits.
+    - Branch flow per owner: feature PR → staging runs checks+e2e (both required); main requires PR + checks with enforce_admins=false so only the owner pushes direct (small fixes skip the e2e bill).
+    - Known risk, accepted: a locally-running `npm run dev` session shares the Trigger dev env with CI and could steal its runs; if flaky, move CI to a Trigger preview branch env.
+
+Implementation summary:
+    - 2 tests: in-scene campaign + on-model plain, 1 option each (4 credits/suite), assert option thumbnail renders and no failure panel, 7-min test timeout.
+    - Secrets set via gh CLI from .env.local (DB, Supabase, Anthropic, Google, Runware, auth, dev Trigger key). TRIGGER_ACCESS_TOKEN still missing — dashboard-minted only; deploy workflow was already blocked on it.
+
+### 2026-07-22 — FAL_KEY purged: "remove Fal" resolved as an env-only ghost
+
+- Type: chore
+- Scope: .env.local, Vercel env (all environments)
+
+Reasoning / RCA / research:
+    - Owner asked to "keep only Runware and remove Fal". Zero Fal references exist in src or package.json — the image stack is Gemini-direct + OpenAI-direct + Runware, and stays that way (direct Gemini was spike-verified better for reference placement).
+    - Fal existed only as an unused FAL_KEY env var locally and on Vercel; removed both so it can't mislead again.
 
 - Type: bug (owner escalation — second correction on the same requirement)
 - Scope: src/app/(app)/studio/[runId]/{page,studio-canvas}.tsx, src/app/(app)/library/{page,library-client}.tsx; deployed (vercel --prod + trigger v20260721.2, git untouched)

--- a/e2e/generation.spec.ts
+++ b/e2e/generation.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Real end-to-end generation through the live pipeline (paid API calls).
+ * Opt-in only: set E2E_REAL_GENERATION=1 (the PR e2e workflow does). Runs in
+ * the seeded "E2E Tests" workspace (scripts/seed-e2e-workspace.ts) against the
+ * cheap-model env (Haiku LLM slots + Nano Banana 2, see .github/workflows/e2e.yml)
+ * and needs the Trigger dev worker running alongside next dev (`npm run dev`).
+ */
+const REAL = process.env.E2E_REAL_GENERATION === "1";
+
+test.describe("real generation (E2E Tests workspace)", () => {
+  test.skip(!REAL, "set E2E_REAL_GENERATION=1 to run the paid generation e2e");
+  // One generation at a time — parallel runs would race the workspace credits
+  // and double the CI bill for no signal.
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(420_000);
+
+  // The seeded workspace (slug "e2e-tests") is permanent in the shared DB, so
+  // its id is stable. Override only if the workspace was ever reseeded fresh.
+  // (No prisma import here: Playwright's transpiler can't resolve the "@/"
+  // alias inside transitively-imported app modules like src/lib/db.ts.)
+  const wsId = process.env.E2E_WORKSPACE_ID ?? "a15a9e76-72e4-4273-a664-0fddf40c74c0";
+
+  test.beforeEach(async ({ context, baseURL }) => {
+    await context.addCookies([
+      // Dev-bypass user is a super-admin: unlock the workspace view and pin
+      // the active workspace to E2E Tests (see src/lib/auth.ts cookies).
+      { name: "sx-admin-acting", value: "1", url: baseURL! },
+      { name: "sx-active-ws", value: wsId, url: baseURL! },
+    ]);
+  });
+
+  async function expectRunCompletes(page: Page) {
+    await expect(page).toHaveURL(/\/studio\/[0-9a-f-]{36}/, { timeout: 60_000 });
+    // A finished option surfaces as a thumbnail in the left rail (composed
+    // render uploaded + creative READY). A failed run renders the destructive
+    // panel instead — assert both directions.
+    const thumb = page.locator('a[href*="?c="] img').first();
+    await expect(thumb).toBeVisible({ timeout: 360_000 });
+    await expect(page.getByText("This run failed")).toHaveCount(0);
+  }
+
+  test("product campaign (in-scene) generates a creative", async ({ page }) => {
+    await page.goto("/studio");
+    // The seeded product is apparel, so it defaults to on-model; switch to the
+    // in-scene campaign mode (which exposes the option-count picker).
+    await page.getByRole("button", { name: /^In-scene / }).click();
+    await page.getByRole("button", { name: "1 option · 2 cr" }).click();
+    await page.getByRole("button", { name: /^Generate 1 option$/ }).click();
+    await expectRunCompletes(page);
+  });
+
+  test("on-model plain e-commerce shot generates a creative", async ({ page }) => {
+    await page.goto("/studio");
+    // Mode cards render as buttons "«title» «description»" — plain text
+    // selectors are ambiguous against the summary rail's value cells.
+    await page.getByRole("button", { name: /^On-model / }).click();
+    await page.getByRole("button", { name: /^Plain image / }).click();
+    // On-model has no "how many options" picker — poses drive the count. Pick
+    // one pose → one image of the model + garment in that pose.
+    await page.getByRole("button", { name: "Standing" }).click();
+    await page.getByRole("button", { name: /^Generate 1 option$/ }).click();
+    await expectRunCompletes(page);
+  });
+});

--- a/prisma/migrations/20260722115500_add_product_image_cutout/migration.sql
+++ b/prisma/migrations/20260722115500_add_product_image_cutout/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "product_images" ADD COLUMN     "cutoutKey" TEXT;

--- a/prisma/migrations/20260722133655_workspace_image_model_and_multipose/migration.sql
+++ b/prisma/migrations/20260722133655_workspace_image_model_and_multipose/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "generation_runs" ADD COLUMN     "modelPoses" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN     "imageModel" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,6 +119,10 @@ model Workspace {
   industry        String?
   primaryUseCase  String?
   salesChannel    String?
+  // Super-admin-only image-model override (a WORKSPACE_IMAGE_MODELS key). Null =
+  // the default quality-first fallback cascade. Used to A/B cheaper models per
+  // workspace (e.g. simple e-commerce apparel doesn't need the premium tier).
+  imageModel      String?
   createdAt       DateTime          @default(now())
   memberships     Membership[]
   invites         WorkspaceInvite[]
@@ -290,6 +294,9 @@ model ProductImage {
   productId  String
   product    Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
   storageKey String
+  // Background-removed packshot (white-flattened PNG), generated once at
+  // upload by the product-cutout task and reused as the generation reference.
+  cutoutKey  String?
   mimeType   String
   width      Int?
   height     Int?
@@ -468,6 +475,10 @@ model GenerationRun {
   brandingMode     BrandingMode      @default(BRANDED)
   // Optional pose direction for on-model apparel (empty = AI varies it per concept).
   modelPose        String?
+  // On-model multi-pose: same model + garment rendered once per pose in a single
+  // run (poses are the variation axis, replacing the concept count). Empty = the
+  // legacy single-concept behavior driven by modelPose/conceptCount.
+  modelPoses       String[]          @default([])
   requestedAspects String[]          @default(["4:5"])
   language         String            @default("en") // creative copy default; all langs generated
   conceptCount     Int               @default(4) // how many distinct creative options to generate (guided runs)

--- a/scripts/seed-e2e-workspace.ts
+++ b/scripts/seed-e2e-workspace.ts
@@ -1,0 +1,188 @@
+/**
+ * Seed the "E2E Tests" workspace used by e2e/generation.spec.ts.
+ * Clones brand kit + one dissected apparel product + brand AI models from the
+ * source workspace (rows only — storage keys are shared, no bytes copied).
+ * Idempotent: keyed on the workspace slug; re-running tops up credits only.
+ *
+ *   npx tsx --env-file=.env.local scripts/seed-e2e-workspace.ts
+ */
+import { prisma } from "@/lib/db";
+
+export const E2E_WORKSPACE_SLUG = "e2e-tests";
+const SOURCE_WORKSPACE_NAME = "Synerix Apparel";
+const DEV_EMAIL = "dev@synerix.local"; // DEV_AUTH_BYPASS user (src/lib/auth.ts)
+const CREDIT_TARGET = 10_000;
+
+async function main() {
+  const existing = await prisma.workspace.findUnique({
+    where: { slug: E2E_WORKSPACE_SLUG },
+    include: { credits: true },
+  });
+  if (existing) {
+    const balance = Number(existing.credits?.balance ?? 0);
+    if (balance < CREDIT_TARGET) {
+      const delta = CREDIT_TARGET - balance;
+      await prisma.$transaction([
+        prisma.workspaceCredits.update({
+          where: { workspaceId: existing.id },
+          data: { balance: CREDIT_TARGET },
+        }),
+        prisma.creditLedger.create({
+          data: { workspaceId: existing.id, delta, reason: "MANUAL_GRANT", balanceAfter: CREDIT_TARGET, note: "E2E top-up" },
+        }),
+      ]);
+      console.log(`E2E workspace exists (${existing.id}) — credits topped up to ${CREDIT_TARGET}`);
+    } else {
+      console.log(`E2E workspace exists (${existing.id}) — nothing to do`);
+    }
+    return;
+  }
+
+  const source = await prisma.workspace.findFirst({
+    where: { name: SOURCE_WORKSPACE_NAME },
+    include: { memberships: true },
+  });
+  if (!source) throw new Error(`Source workspace "${SOURCE_WORKSPACE_NAME}" not found`);
+
+  const sourceBrand = await prisma.brand.findFirst({
+    where: { workspaceId: source.id },
+    include: { assets: true, aiModels: { where: { status: "READY", scope: "BRAND" } } },
+  });
+  if (!sourceBrand) throw new Error("Source workspace has no brand");
+
+  const sourceProduct = await prisma.product.findFirst({
+    where: { brandId: sourceBrand.id, dissectionStatus: "READY", images: { some: {} } },
+    include: { images: { orderBy: [{ isPrimary: "desc" }, { createdAt: "asc" }] } },
+  });
+  if (!sourceProduct) throw new Error("Source brand has no dissected product with images");
+
+  const devUser = await prisma.user.upsert({
+    where: { email: DEV_EMAIL },
+    update: {},
+    create: { email: DEV_EMAIL, name: "Dev User" },
+  });
+
+  const ws = await prisma.$transaction(async (tx) => {
+    const ws = await tx.workspace.create({
+      data: {
+        name: "E2E Tests",
+        slug: E2E_WORKSPACE_SLUG,
+        ownerUserId: source.ownerUserId,
+        type: source.type,
+      },
+    });
+
+    // Members: the dev-bypass user (the e2e runner) + everyone from the source
+    // workspace (so the owner can inspect e2e output in the real UI).
+    const memberRows = [
+      { workspaceId: ws.id, userId: devUser.id, role: "OWNER" as const },
+      ...source.memberships
+        .filter((m) => m.userId !== devUser.id)
+        .map((m) => ({ workspaceId: ws.id, userId: m.userId, role: m.role })),
+    ];
+    await tx.membership.createMany({ data: memberRows, skipDuplicates: true });
+
+    await tx.workspaceCredits.create({ data: { workspaceId: ws.id, balance: CREDIT_TARGET } });
+    await tx.creditLedger.create({
+      data: { workspaceId: ws.id, delta: CREDIT_TARGET, reason: "MANUAL_GRANT", balanceAfter: CREDIT_TARGET, note: "E2E seed grant" },
+    });
+
+    const brand = await tx.brand.create({
+      data: {
+        workspaceId: ws.id,
+        name: sourceBrand.name,
+        websiteUrl: sourceBrand.websiteUrl,
+        mottoText: sourceBrand.mottoText,
+        dna: sourceBrand.dna ?? undefined,
+        dnaConfidence: sourceBrand.dnaConfidence ?? undefined,
+        primaryColorHex: sourceBrand.primaryColorHex,
+        secondaryColorsHex: sourceBrand.secondaryColorsHex,
+        accentColorsHex: sourceBrand.accentColorsHex,
+        typographyStyle: sourceBrand.typographyStyle,
+        photographyStyle: sourceBrand.photographyStyle,
+        voiceRegister: sourceBrand.voiceRegister,
+        oneLiner: sourceBrand.oneLiner,
+        logoCorner: sourceBrand.logoCorner,
+        logoScale: sourceBrand.logoScale,
+        contactLine: sourceBrand.contactLine,
+        apparelBrandingDefault: sourceBrand.apparelBrandingDefault,
+        creativeIntel: sourceBrand.creativeIntel ?? undefined,
+        creativeIntelAt: sourceBrand.creativeIntelAt,
+        ingestStatus: "READY",
+      },
+    });
+
+    for (const a of sourceBrand.assets) {
+      await tx.brandAsset.create({
+        data: {
+          brandId: brand.id,
+          kind: a.kind,
+          storageKey: a.storageKey, // shared bytes
+          mimeType: a.mimeType,
+          width: a.width,
+          height: a.height,
+          sourceUrl: a.sourceUrl,
+          classification: a.classification ?? undefined,
+          isPrimaryLogo: a.isPrimaryLogo,
+        },
+      });
+    }
+
+    const product = await tx.product.create({
+      data: {
+        brandId: brand.id,
+        name: sourceProduct.name,
+        sku: sourceProduct.sku,
+        description: sourceProduct.description,
+        category: sourceProduct.category,
+        dissectionPrompt: sourceProduct.dissectionPrompt,
+        dissectionFull: sourceProduct.dissectionFull ?? undefined,
+        productIntel: sourceProduct.productIntel ?? undefined,
+        dissectionStatus: "READY",
+      },
+    });
+    for (const img of sourceProduct.images) {
+      await tx.productImage.create({
+        data: {
+          productId: product.id,
+          storageKey: img.storageKey, // shared bytes
+          cutoutKey: img.cutoutKey,
+          mimeType: img.mimeType,
+          width: img.width,
+          height: img.height,
+          isPrimary: img.isPrimary,
+        },
+      });
+    }
+    // Dissection cache is keyed to the source image id, which we didn't clone.
+    const primary = await tx.productImage.findFirst({ where: { productId: product.id, isPrimary: true } });
+    await tx.product.update({
+      where: { id: product.id },
+      data: { dissectionSourceImageId: primary?.id ?? null },
+    });
+
+    for (const m of sourceBrand.aiModels) {
+      await tx.aiModel.create({
+        data: {
+          scope: "BRAND",
+          brandId: brand.id,
+          name: m.name,
+          description: m.description,
+          traits: m.traits ?? undefined,
+          storageKey: m.storageKey, // shared bytes
+          mimeType: m.mimeType,
+          width: m.width,
+          height: m.height,
+          status: "READY",
+        },
+      });
+    }
+
+    return ws;
+  });
+
+  console.log(`Seeded E2E workspace ${ws.id} (slug ${E2E_WORKSPACE_SLUG})`);
+  console.log(`  product: ${sourceProduct.name}, brand: ${sourceBrand.name}, aiModels cloned: ${sourceBrand.aiModels.length}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,13 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+
+// Server actions POST to the page that hosts the form, so the function limit
+// for every app-shell action lives here. The Vercel default (10s) killed the
+// generate action mid-flight on cold starts (auth + ~8 Supabase round-trips +
+// Trigger enqueue) — the run was already enqueued, so the user saw the crash
+// page while the generation kept going. 60s absorbs the worst cold path; all
+// genuinely slow work already lives in Trigger tasks, not actions.
+export const maxDuration = 60;
 import { requireAuth, ADMIN_ACTING_COOKIE } from "@/lib/auth";
 import { getBalance } from "@/lib/credits";
 import { prisma } from "@/lib/db";

--- a/src/app/(app)/library/[creativeId]/editor.tsx
+++ b/src/app/(app)/library/[creativeId]/editor.tsx
@@ -367,6 +367,7 @@ export function CreativeEditor(props: {
         renders={props.renders}
         missingAspects={missingAspects}
         addAspectPending={aspectPending}
+        aspectCostLabel={props.costs.regen}
         onAddAspect={(a) =>
           mutate(startAspect, () => renderNewAspect(id, a), `${a} format rendered`, undefined, "aspect")
         }

--- a/src/app/(app)/library/[creativeId]/preview-stage.tsx
+++ b/src/app/(app)/library/[creativeId]/preview-stage.tsx
@@ -44,6 +44,8 @@ export function PreviewStage(props: {
   missingAspects: Aspect[];
   onAddAspect: (aspect: Aspect) => void;
   addAspectPending: boolean;
+  /** Credit cost label for rendering a new native format (e.g. "2"). */
+  aspectCostLabel: string;
   busy: boolean;
   busyLabel?: string;
   approved: boolean;
@@ -158,10 +160,10 @@ export function PreviewStage(props: {
             disabled={props.addAspectPending || props.busy}
             onClick={() => props.onAddAspect(a)}
             className="rounded-full border-dashed text-muted-foreground"
-            title={`Render ${a} (free)`}
+            title={`Render a native ${a} — ${props.aspectCostLabel} credits`}
           >
             {props.addAspectPending ? <Loader2 className="animate-spin" data-icon="inline-start" /> : <Plus data-icon="inline-start" />}
-            {a} <span className="text-[10px] font-semibold uppercase tracking-wide opacity-70">Free</span>
+            {a} <span className="text-[10px] font-semibold uppercase tracking-wide opacity-70">{props.aspectCostLabel} cr</span>
           </Button>
         ))}
         <span className="flex-1" />

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,5 +1,6 @@
 import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
+import { WORKSPACE_IMAGE_MODELS } from "@/lib/image/provider";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SettingsClient } from "./settings-client";
 
@@ -40,6 +41,9 @@ export default async function SettingsPage() {
             <SettingsClient
               workspaceName={workspace.name}
               canManage={canManage}
+              isSuperAdmin={ctx.isSuperAdmin}
+              imageModel={workspace.imageModel}
+              imageModelOptions={WORKSPACE_IMAGE_MODELS.map((m) => ({ key: m.key, label: m.label, hint: m.hint }))}
               currentUserId={ctx.userId}
               members={members.map((m) => ({
                 membershipId: m.id,

--- a/src/app/(app)/settings/settings-client.tsx
+++ b/src/app/(app)/settings/settings-client.tsx
@@ -9,6 +9,7 @@ import {
   renameWorkspace,
   resendInvite,
   revokeInvite,
+  setWorkspaceImageModel,
   updateMemberRole,
 } from "@/app/actions/workspace";
 import { Badge } from "@/components/ui/badge";
@@ -61,15 +62,21 @@ function errorMessage(e: unknown) {
   return e instanceof Error ? e.message : "Something went wrong";
 }
 
+const DEFAULT_MODEL = "__default__"; // Select needs a non-empty value for "use cascade"
+
 export function SettingsClient(props: {
   workspaceName: string;
   canManage: boolean;
+  isSuperAdmin: boolean;
+  imageModel: string | null;
+  imageModelOptions: { key: string; label: string; hint: string }[];
   currentUserId: string;
   members: Member[];
   invites: Invite[];
 }) {
   const [pending, startTransition] = useTransition();
   const [wsName, setWsName] = useState(props.workspaceName);
+  const [imageModel, setImageModel] = useState(props.imageModel ?? DEFAULT_MODEL);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState("EDITOR");
 
@@ -106,6 +113,43 @@ export function SettingsClient(props: {
             >
               Save
             </Button>
+          </div>
+          <Separator />
+        </>
+      )}
+
+      {/* Image model — platform super-admin only. Sets the model every run in
+          this workspace prefers (fallback cascade kept behind it). */}
+      {props.isSuperAdmin && (
+        <>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex-1 space-y-1.5">
+              <Label>Image model (admin)</Label>
+              <Select
+                value={imageModel}
+                onValueChange={(v) => {
+                  if (!v || v === imageModel) return;
+                  setImageModel(v);
+                  run(() => setWorkspaceImageModel(v === DEFAULT_MODEL ? null : v), "Image model updated");
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={DEFAULT_MODEL}>Default (quality-first cascade)</SelectItem>
+                  {props.imageModelOptions.map((m) => (
+                    <SelectItem key={m.key} value={m.key}>
+                      {m.label} — {m.hint}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Only you (platform admin) can see and change this. Every generation in this workspace prefers the chosen
+                model; the resilience fallback cascade stays behind it.
+              </p>
+            </div>
           </div>
           <Separator />
         </>

--- a/src/app/(app)/studio/create-form.tsx
+++ b/src/app/(app)/studio/create-form.tsx
@@ -76,7 +76,11 @@ export function CreateForm(props: {
   const [renderMode, setRenderMode] = useState<"in_scene" | "composite" | "on_model">("in_scene");
   const [aiModelId, setAiModelId] = useState<string | null>(props.aiModels[0]?.id ?? null);
   const [brandingMode, setBrandingMode] = useState<BrandingMode>(props.apparelBrandingDefault);
-  const [pose, setPose] = useState("");
+  // On-model poses (multi-select): each selected pose → one image of the SAME
+  // model + garment. Empty = a single AI-varied pose. `customPose` is appended
+  // as one more pose when filled.
+  const [poses, setPoses] = useState<string[]>([]);
+  const [customPose, setCustomPose] = useState("");
   const [language, setLanguage] = useState("en");
   const [optionCount, setOptionCount] = useState(LIMITS.maxConceptsPerRun);
   const [aspects, setAspects] = useState<string[]>(["4:5"]);
@@ -121,7 +125,13 @@ export function CreateForm(props: {
   const hasOccasion = props.isOccasion || (!direct && Boolean(pickedOccasion));
   // A selected product is a complete brief by itself — free text stays optional.
   const briefOptional = hasOccasion || Boolean(selectedProduct);
-  const cost = direct ? CREDIT_COSTS.perConcept : CREDIT_COSTS.perConcept * optionCount;
+  // On-model: the selected poses ARE the options (same model+garment, one image
+  // per pose). Empty selection = a single AI-varied pose. Elsewhere the option
+  // count drives it.
+  const effectivePoses = [...poses, customPose.trim()].filter(Boolean);
+  const onModelCount = Math.max(1, effectivePoses.length);
+  const guidedCount = onModel ? onModelCount : optionCount;
+  const cost = direct ? CREDIT_COSTS.perConcept : CREDIT_COSTS.perConcept * guidedCount;
   const insufficient = props.creditBalance < cost;
   const needsModel = onModel && !aiModelId;
   const langLabel = LANGS.find((l) => l.id === language)?.label ?? language;
@@ -158,10 +168,13 @@ export function CreateForm(props: {
     if (fidelityMode === "ON_MODEL" && aiModelId) fd.set("aiModelId", aiModelId);
     if (fidelityMode === "ON_MODEL") {
       fd.set("brandingMode", brandingMode);
-      if (pose.trim()) fd.set("modelPose", pose.trim());
+      // Multi-pose: each pose → one image (same model+garment). JSON-encoded so
+      // pose text can contain any character. Empty = single AI-varied pose.
+      fd.set("modelPoses", JSON.stringify(effectivePoses));
     }
     fd.set("language", language);
-    fd.set("optionCount", String(optionCount));
+    // On-model uses the pose count as its option count; everything else the picker.
+    fd.set("optionCount", String(guidedCount));
     fd.set("aspects", aspects.join(","));
     startTransition(async () => {
       setError(null);
@@ -340,22 +353,39 @@ export function CreateForm(props: {
                     </div>
                   </div>
 
-                  {/* Model pose */}
+                  {/* Model poses — MULTI-select. Each selected pose becomes one
+                      image of the same model + garment (poses replace the option
+                      count for on-model runs). */}
                   <div className="mt-4">
-                    <Label className="text-xs uppercase tracking-wide text-muted-foreground">Model pose</Label>
+                    <Label className="text-xs uppercase tracking-wide text-muted-foreground">Poses & angles</Label>
                     <div className="mt-3 flex flex-wrap gap-2">
-                      {POSES.map((p) => (
-                        <Pill key={p.label} active={pose === p.value} onClick={() => setPose(p.value)}>{p.label}</Pill>
-                      ))}
+                      {POSES.filter((p) => p.value).map((p) => {
+                        const on = poses.includes(p.value);
+                        return (
+                          <Pill
+                            key={p.label}
+                            active={on}
+                            onClick={() =>
+                              setPoses((prev) => (on ? prev.filter((v) => v !== p.value) : [...prev, p.value]))
+                            }
+                          >
+                            {p.label}
+                          </Pill>
+                        );
+                      })}
                     </div>
                     <Input
-                      value={pose}
-                      onChange={(e) => setPose(e.target.value)}
+                      value={customPose}
+                      onChange={(e) => setCustomPose(e.target.value)}
                       maxLength={200}
-                      placeholder="…or describe a custom pose (e.g. mid-twirl showing the dupatta)"
+                      placeholder="…add a custom pose (e.g. mid-twirl showing the dupatta)"
                       className="mt-3"
                     />
-                    <p className="mt-1.5 text-xs text-muted-foreground">Leave on “Auto” to let the AI vary the pose per option.</p>
+                    <p className="mt-1.5 text-xs text-muted-foreground">
+                      {onModelCount === 1
+                        ? "One image — pick poses to get the same model & outfit in each."
+                        : `${onModelCount} images · same model & garment, one per pose · ${cost} cr`}
+                    </p>
                   </div>
                 </div>
               )}
@@ -454,8 +484,9 @@ export function CreateForm(props: {
             </section>
           </div>
 
-          {/* How many options to generate (guided only) — drives cost. */}
-          {!direct && (
+          {/* How many options to generate (guided only) — drives cost. Hidden
+              for on-model runs, where the selected poses drive the count. */}
+          {!direct && !onModel && (
             <section>
               <Label className="text-xs uppercase tracking-wide text-muted-foreground">How many options?</Label>
               <div className="mt-3 flex flex-wrap gap-2">
@@ -488,6 +519,7 @@ export function CreateForm(props: {
             )}
             {onModel && <SummaryRow label="Model" value={selectedModel?.name ?? "Not selected"} />}
             {onModel && <SummaryRow label="Output" value={brandingMode === "PLAIN" ? "Plain image" : "Branded campaign"} />}
+            {onModel && <SummaryRow label="Poses" value={`${onModelCount} ${onModelCount === 1 ? "pose" : "poses"}`} />}
             {!direct && <SummaryRow label="Language" value={langLabel} />}
             <SummaryRow label="Formats" value={aspectLabels.join(", ")} />
           </dl>
@@ -522,7 +554,7 @@ export function CreateForm(props: {
                   ? "Pick a model"
                   : direct
                     ? "Generate creative"
-                    : `Generate ${optionCount} ${optionCount === 1 ? "option" : "options"}`}
+                    : `Generate ${guidedCount} ${guidedCount === 1 ? "option" : "options"}`}
           </Button>
 
           <p className="text-center text-xs text-muted-foreground">

--- a/src/app/actions/editor.ts
+++ b/src/app/actions/editor.ts
@@ -26,21 +26,19 @@ async function startCreativeEdit(
   payload: CreativeEditPayload,
   note: string,
 ): Promise<PendingEdit | { error: string }> {
-  // render_aspect is a FREE recomposite: no debit here, and neither this
-  // function nor the task's catchError may refund for it.
-  const paid = payload.kind !== "render_aspect";
-  if (paid) {
-    try {
-      await debitCredits({
-        workspaceId: payload.workspaceId,
-        amount: CREDIT_COSTS.regenInstruction,
-        reason: "REGEN_INSTRUCTION",
-        note,
-      });
-    } catch (e) {
-      if (e instanceof InsufficientCreditsError) return { error: "Not enough credits" };
-      throw e;
-    }
+  // Every edit kind is a paid image-model call (render_aspect now generates a
+  // native plate for the new ratio, no longer a free crop). Debit up front so
+  // InsufficientCredits surfaces synchronously; refunds happen on failure.
+  try {
+    await debitCredits({
+      workspaceId: payload.workspaceId,
+      amount: CREDIT_COSTS.regenInstruction,
+      reason: "REGEN_INSTRUCTION",
+      note,
+    });
+  } catch (e) {
+    if (e instanceof InsufficientCreditsError) return { error: "Not enough credits" };
+    throw e;
   }
 
   let handle;
@@ -49,14 +47,12 @@ async function startCreativeEdit(
       tags: [`creative:${payload.creativeId}`, `ws:${payload.workspaceId}`],
     });
   } catch (e) {
-    if (paid) {
-      await grantCredits({
-        workspaceId: payload.workspaceId,
-        amount: CREDIT_COSTS.regenInstruction,
-        reason: "REFUND",
-        note: "Edit could not be queued — refunded",
-      });
-    }
+    await grantCredits({
+      workspaceId: payload.workspaceId,
+      amount: CREDIT_COSTS.regenInstruction,
+      reason: "REFUND",
+      note: "Edit could not be queued — refunded",
+    });
     return { error: `Could not start the edit: ${(e as Error).message?.slice(0, 160)}` };
   }
 
@@ -274,8 +270,8 @@ export async function renderNewAspect(creativeId: string, aspect: Aspect) {
   if (!creative.masterPlateKey) return { error: "Creative has no master scene" };
   if (creative.renders.some((r) => r.aspectRatio === aspect)) return { ok: true };
 
-  // Free, but the full-res plate download + composite + upload can outlive a
-  // serverless action — run it in the creative-edit task (no credit debit).
+  // Paid: generates a NATIVE plate for the new ratio (correct framing, not a
+  // crop) in the creative-edit task. startCreativeEdit debits + refunds.
   return startCreativeEdit(
     { kind: "render_aspect", creativeId, workspaceId: auth.workspaceId, aspect },
     `New ${aspect} format`,

--- a/src/app/actions/generate.ts
+++ b/src/app/actions/generate.ts
@@ -20,6 +20,9 @@ const startSchema = z.object({
   brandingMode: z.enum(["BRANDED", "PLAIN"]).optional().or(z.literal("")),
   // Optional pose direction for on-model apparel (empty = AI varies it).
   modelPose: z.string().trim().max(200).optional().or(z.literal("")),
+  // Multi-pose (on-model): JSON array of pose strings; each → one image of the
+  // same model + garment. Empty/absent = a single AI-varied pose.
+  modelPoses: z.string().optional().or(z.literal("")),
   aiModelId: z.string().uuid().optional().or(z.literal("")), // required for ON_MODEL
   directMode: z.string().optional(), // "1" → literal prompt, skip concepting
   bakeoff: z.string().optional(), // "1" → super-admin model bake-off (no debit)
@@ -116,11 +119,33 @@ export async function startGenerationRun(formData: FormData) {
     aiModelId = model.id;
   }
 
-  // Direct mode = 1 render. Guided = N concepts (user-chosen, capped).
-  // "Compare" renders every option on both premium models → double credits.
-  // Bake-off renders each concept once per model variant but debits nothing —
-  // API spend still lands in ApiCostLog.
-  const conceptCount = directMode ? 1 : d.optionCount;
+  // On-model multi-pose: each selected pose is one image of the same model +
+  // garment, so the pose count IS the option count. Parse + sanitize here.
+  let modelPoses: string[] = [];
+  if (d.fidelityMode === "ON_MODEL" && d.modelPoses) {
+    try {
+      const parsed = JSON.parse(d.modelPoses);
+      if (Array.isArray(parsed)) {
+        modelPoses = parsed
+          .filter((p): p is string => typeof p === "string")
+          .map((p) => p.trim())
+          .filter(Boolean)
+          .slice(0, LIMITS.maxConceptsPerRun);
+      }
+    } catch {
+      return { error: "Invalid pose selection" };
+    }
+  }
+
+  // Direct mode = 1 render. On-model = one render per selected pose (min 1).
+  // Guided = N concepts (user-chosen, capped). "Compare" renders every option on
+  // both premium models → double credits. Bake-off debits nothing (API spend
+  // still lands in ApiCostLog).
+  const conceptCount = directMode
+    ? 1
+    : d.fidelityMode === "ON_MODEL"
+      ? Math.max(1, modelPoses.length)
+      : d.optionCount;
   const variantMultiplier = d.imageModel === "compare" ? 2 : 1;
   const cost = bakeoff ? 0 : CREDIT_COSTS.perConcept * conceptCount * variantMultiplier;
 
@@ -143,6 +168,7 @@ export async function startGenerationRun(formData: FormData) {
       fidelityMode: d.fidelityMode,
       brandingMode,
       modelPose: d.fidelityMode === "ON_MODEL" ? (d.modelPose || null) : null,
+      modelPoses,
       aiModelId,
       requestedAspects,
       language: d.language,

--- a/src/app/actions/products.ts
+++ b/src/app/actions/products.ts
@@ -9,6 +9,7 @@ import { requireAuth } from "@/lib/auth";
 import { ensureBrand } from "@/lib/ensure-brand";
 import { storageKeys, uploadBuffer } from "@/lib/storage";
 import type { productDissect } from "@/trigger/product-dissect";
+import type { productCutout } from "@/trigger/product-cutout";
 
 const MAX_IMAGES = 5;
 const MAX_BYTES = 8 * 1024 * 1024;
@@ -60,6 +61,7 @@ export async function createProduct(formData: FormData) {
   }
 
   await tasks.trigger<typeof productDissect>("product-dissect", { productId: product.id });
+  await tasks.trigger<typeof productCutout>("product-cutout", { productId: product.id });
   revalidatePath("/products");
   return { ok: true, productId: product.id };
 }
@@ -95,6 +97,7 @@ export async function createProductInline(formData: FormData) {
   });
 
   await tasks.trigger<typeof productDissect>("product-dissect", { productId: product.id });
+  await tasks.trigger<typeof productCutout>("product-cutout", { productId: product.id });
   revalidatePath("/products");
   return {
     product: {
@@ -135,6 +138,7 @@ export async function addProductImages(productId: string, formData: FormData) {
     });
   }
 
+  await tasks.trigger<typeof productCutout>("product-cutout", { productId: product.id });
   revalidatePath(`/products/${product.id}`);
   revalidatePath("/products");
   return { ok: true };

--- a/src/app/actions/workspace.ts
+++ b/src/app/actions/workspace.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { sendInviteEmail } from "@/lib/email";
+import { WORKSPACE_IMAGE_MODELS } from "@/lib/image/provider";
 import { MembershipRole } from "@/generated/prisma/client";
 
 const MANAGER_ROLES = new Set(["OWNER", "ADMIN"]);
@@ -35,6 +36,16 @@ export async function renameWorkspace(name: string) {
   const trimmed = name.trim();
   if (trimmed.length < 2 || trimmed.length > 60) throw new Error("Name must be 2–60 characters");
   await prisma.workspace.update({ where: { id: ctx.workspaceId }, data: { name: trimmed } });
+  revalidatePath("/settings");
+}
+
+/** Super-admin-only: set (or clear) the workspace's image-model override. */
+export async function setWorkspaceImageModel(modelKey: string | null) {
+  const ctx = await requireAuth();
+  if (!ctx.isSuperAdmin) throw new Error("Only platform admins can change the image model");
+  const key = modelKey || null;
+  if (key && !WORKSPACE_IMAGE_MODELS.some((m) => m.key === key)) throw new Error("Unknown image model");
+  await prisma.workspace.update({ where: { id: ctx.workspaceId }, data: { imageModel: key } });
   revalidatePath("/settings");
 }
 

--- a/src/lib/editor/paid-edits.ts
+++ b/src/lib/editor/paid-edits.ts
@@ -5,7 +5,8 @@ import { downloadFromStorage, storageKeys, uploadBuffer } from "@/lib/storage";
 import { renderOverlay } from "@/lib/composition/render";
 import { buildOverlaySpec } from "@/lib/composition/archetypes";
 import { analyzePlate } from "@/lib/composition/analyze";
-import { generateScene, type SceneAspect as Aspect } from "@/lib/image/provider";
+import { generateScene, resolveWorkspaceImageModel, type SceneAspect as Aspect } from "@/lib/image/provider";
+import { buildOnModelPrompt, buildScenePassPrompt } from "@/lib/pipeline/image-prompt";
 import { CostTracker } from "@/lib/pipeline/cost";
 import { persistCost } from "@/lib/pipeline/cost-log";
 import { checkBakedText } from "@/lib/pipeline/text-qa";
@@ -118,26 +119,82 @@ export async function recompositeAll(
   });
 }
 
-/** Compose one additional aspect from the existing master plate — FREE (pure
- * recomposite, no AI call, no credits). Runs in the creative-edit task because
- * the full-res plate download + composite + upload can outlive a serverless
- * action. Returns {error} instead of throwing (nothing to refund). */
+/** Render one additional aspect by generating a NATIVE plate for that ratio via
+ * the image model (correct framing, not a crop of the master plate), then
+ * compositing text/logo. Paid: the caller debits before triggering; this
+ * refunds on a handled failure (the task's catchError covers crashes). */
 export async function applyRenderAspect(
   creative: LoadedCreative,
   aspect: Aspect,
+  workspaceId: string,
 ): Promise<{ ok: true } | { error: string }> {
   if (!creative.masterPlateKey) return { error: "Creative has no master scene" };
   if (creative.renders.some((r) => r.aspectRatio === aspect)) return { ok: true };
 
+  const refund = (note: string) =>
+    grantCredits({ workspaceId, amount: CREDIT_COSTS.regenInstruction, reason: "REFUND", note }).catch(() => {});
+
   try {
-    const concept = creative.concept as unknown as CreativeConcept;
+    const concept = creative.concept as unknown as CreativeConcept & { pose?: string; aspectPlateKeys?: Record<string, string> };
     const refSpec = creative.renders[0]?.overlaySpec as unknown as OverlaySpec | undefined;
-    // Preserve the contact-line visibility chosen on existing renders.
+
+    // Reload the generating run for references + fidelity framing so the new
+    // plate is a faithful native render of the SAME scene at the new ratio.
+    const run = await prisma.generationRun.findUnique({
+      where: { id: creative.generationRunId },
+      include: {
+        product: { include: { images: { orderBy: [{ isPrimary: "desc" }], take: 1 } } },
+        aiModel: true,
+        workspace: { select: { type: true, imageModel: true } },
+      },
+    });
+    const onModel = run?.fidelityMode === "ON_MODEL";
+    const productImage = run?.product?.images[0] ?? null;
+    // Prefer the cached cutout (clean packshot) as reference, like generation.
+    const refBuffer = productImage
+      ? await downloadFromStorage(productImage.cutoutKey ?? productImage.storageKey)
+      : null;
+    const refMime = productImage?.cutoutKey ? "image/png" : (productImage?.mimeType ?? "image/png");
+    // Honour the workspace image-model setting (soft-prefer, fallback kept).
+    const wsVariant = resolveWorkspaceImageModel(run?.workspace?.imageModel);
+    const model = wsVariant
+      ? { provider: wsVariant.provider, tier: wsVariant.tier, softPrefer: true as const, runwareModel: wsVariant.runwareModel }
+      : {};
+
+    const tracker = new CostTracker();
+    let plate: Buffer;
+    if (onModel && run?.aiModel?.storageKey && refBuffer && productImage) {
+      const modelBuffer = await downloadFromStorage(run.aiModel.storageKey);
+      const prompt = buildOnModelPrompt({
+        concept,
+        aspect,
+        garmentPrompt: run.product?.dissectionPrompt,
+        pose: concept.pose ?? run.modelPose,
+        direction: run.workspace?.type === "FASHION_EDITORIAL" ? "editorial" : "catalog",
+        plain: run.brandingMode === "PLAIN",
+      });
+      const refs = [
+        { buffer: modelBuffer, mime: run.aiModel.mimeType ?? "image/png" },
+        { buffer: refBuffer, mime: refMime },
+      ];
+      const gen = await generateScene({ prompt, aspect, references: refs, ...model });
+      tracker.addImage(gen.costModel, "render-aspect");
+      plate = gen.buffer;
+    } else {
+      const hasProduct = Boolean(refBuffer);
+      const refs = hasProduct && productImage ? [{ buffer: refBuffer!, mime: refMime }] : undefined;
+      const prompt = buildScenePassPrompt({ concept, aspect, dissectionPrompt: run?.product?.dissectionPrompt, hasProduct });
+      const gen = await generateScene({ prompt, aspect, references: refs, ...model });
+      tracker.addImage(gen.costModel, "render-aspect");
+      plate = gen.buffer;
+    }
+
+    // Persist the native plate as THIS aspect's own plate key so later text /
+    // language edits re-composite from it (not from a cropped master).
+    const plateKey = storageKeys.masterPlate(creative.generationRunId, `${creative.conceptIndex}-${aspect.replace(":", "x")}`);
+    await uploadBuffer(plateKey, plate, "image/png");
+
     const showContact = Boolean(refSpec?.textLayers.some((l) => l.role === "contact"));
-    // Cover-fitting the master plate into a NEW aspect is a large crop; analyse
-    // it so buildOverlaySpec anchors the crop to the subject (plateFocusY) and
-    // the head/feet aren't clipped — same guard the generator applies.
-    const plate = await downloadFromStorage(creative.masterPlateKey);
     const analysis = await analyzePlate(plate).catch(() => null);
     const spec = buildOverlaySpec({
       archetype: concept.archetype,
@@ -151,8 +208,6 @@ export async function applyRenderAspect(
         primaryColorHex: creative.brand.primaryColorHex ?? concept.paletteHexes[0],
         accentColorHex: creative.brand.accentColorsHex[0] ?? concept.paletteHexes[1] ?? null,
       },
-      // Preserve the type pairing the creative was generated with, so a newly
-      // rendered aspect matches its siblings.
       typePairingId: refSpec?.theme?.typePairing,
       dominantColors: analysis?.dominant,
       placement: analysis ? { safeBand: analysis.safeBand, busyness: analysis.busyness } : undefined,
@@ -173,17 +228,28 @@ export async function applyRenderAspect(
     const composed = await renderOverlay(spec, { plate, logo });
     const key = storageKeys.composedRender(creative.id, aspect, creative.versions[0]?.index ?? 0);
     await uploadBuffer(key, composed, "image/png");
-    await prisma.creativeRender.create({
-      data: {
-        creativeId: creative.id,
-        aspectRatio: aspect,
-        overlaySpec: spec as unknown as Prisma.InputJsonValue,
-        composedImageKey: key,
-        status: "COMPOSED",
-      },
-    });
+
+    const nextAspectPlateKeys = { ...(concept.aspectPlateKeys ?? {}), [aspect]: plateKey };
+    await prisma.$transaction([
+      prisma.creativeRender.create({
+        data: {
+          creativeId: creative.id,
+          aspectRatio: aspect,
+          overlaySpec: spec as unknown as Prisma.InputJsonValue,
+          composedImageKey: key,
+          status: "COMPOSED",
+        },
+      }),
+      prisma.creative.update({
+        where: { id: creative.id },
+        data: { concept: { ...concept, aspectPlateKeys: nextAspectPlateKeys } as unknown as Prisma.InputJsonValue },
+      }),
+    ]);
+
+    await persistCost({ summary: tracker.summary(), source: "editor", workspaceId, runId: creative.generationRunId });
     return { ok: true };
   } catch (e) {
+    await refund("New format render failed — refunded");
     return { error: `Render failed: ${(e as Error).message?.slice(0, 200)}` };
   }
 }

--- a/src/lib/image/provider.test.ts
+++ b/src/lib/image/provider.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { closestGptSize, resolveSceneChain } from "./provider";
+import {
+  closestGptSize,
+  resolveSceneChain,
+  resolveWorkspaceImageModel,
+  WORKSPACE_IMAGE_MODELS,
+} from "./provider";
 import { ASPECT_DIMENSIONS } from "@/lib/composition/types";
 
 describe("resolveSceneChain — quality-first fallback cascade", () => {
@@ -34,6 +39,32 @@ describe("resolveSceneChain — quality-first fallback cascade", () => {
       { provider: "gemini", tier: "default" },
       { provider: "seedream", tier: "default" },
     ]);
+  });
+});
+
+describe("workspace image-model picker", () => {
+  it("null / unknown key falls back to the default cascade (no leading pick)", () => {
+    expect(resolveWorkspaceImageModel(null)).toBeUndefined();
+    expect(resolveWorkspaceImageModel("not-a-model")).toBeUndefined();
+  });
+
+  it("a Runware model resolves to a soft-prefer seedream variant carrying its model key", () => {
+    const v = resolveWorkspaceImageModel("qwen-image");
+    expect(v).toMatchObject({ provider: "seedream", runwareModel: "qwen_image", soft: true, key: "" });
+  });
+
+  it("a Runware pick leads but the fallback cascade behind it never inherits its model key", () => {
+    const v = resolveWorkspaceImageModel("wan-2.7")!;
+    const chain = resolveSceneChain({ provider: v.provider, tier: v.tier, softPrefer: true, runwareModel: v.runwareModel });
+    // Leading step carries the chosen Runware model...
+    expect(chain[0]).toMatchObject({ provider: "seedream", runwareModel: "wan_2_7" });
+    // ...but the seedream fallback step (Seedream v4) must NOT inherit it.
+    const seedreamFallbacks = chain.slice(1).filter((s) => s.provider === "seedream");
+    for (const s of seedreamFallbacks) expect(s.runwareModel).toBeUndefined();
+  });
+
+  it("every registry variant key matches its map key (no drift)", () => {
+    for (const m of WORKSPACE_IMAGE_MODELS) expect(m.variant.key).toBe(m.key);
   });
 });
 

--- a/src/lib/image/provider.ts
+++ b/src/lib/image/provider.ts
@@ -33,6 +33,9 @@ export interface SceneGenParams {
   softPrefer?: boolean;
   /** Gemini model tier; defaults to Nano Banana 2. */
   tier?: ImageTier;
+  /** With `provider: "seedream"` (Runware): which Runware model id/key to use.
+   * Defaults to Seedream v4. Lets one provider expose several Runware models. */
+  runwareModel?: string;
   negativePrompt?: string;
 }
 
@@ -60,6 +63,8 @@ export interface BakeoffVariant {
   key: string;
   provider: ImageProvider;
   tier: ImageTier;
+  /** For seedream/Runware variants: the specific Runware model key. */
+  runwareModel?: string;
 }
 export const BAKEOFF_VARIANTS: BakeoffVariant[] = [
   { key: "nb2", provider: "gemini", tier: "default" },
@@ -93,18 +98,57 @@ export function variantsForPref(pref: string | null | undefined): Array<BakeoffV
   return [undefined]; // legacy runs (pre-picker): default chain
 }
 
+/**
+ * Super-admin workspace image-model picker. Each key maps to a render variant
+ * (provider + tier, and a Runware model for the seedream provider). The chosen
+ * model becomes the workspace's leading pick with the full fallback cascade kept
+ * behind it (a paid run must survive an outage), so this is a quality/cost knob,
+ * not a hard pin. `null` (no selection) = the default quality-first cascade.
+ */
+export interface WorkspaceImageModel {
+  key: string;
+  label: string;
+  hint: string;
+  variant: BakeoffVariant;
+}
+export const WORKSPACE_IMAGE_MODELS: WorkspaceImageModel[] = [
+  { key: "nb-pro", label: "Nano Banana Pro", hint: "Premium · best pack & label fidelity", variant: { key: "nb-pro", provider: "gemini", tier: "hero" } },
+  { key: "nb2", label: "Nano Banana 2", hint: "Cheaper Google · fast, great for simple shots", variant: { key: "nb2", provider: "gemini", tier: "default" } },
+  { key: "gpt-image-2", label: "GPT Image 2", hint: "Premium alternative render", variant: { key: "gpt-image-2", provider: "gpt-image-2", tier: "hero" } },
+  { key: "seedream-v4", label: "Seedream v4", hint: "Runware · strong & inexpensive", variant: { key: "seedream-v4", provider: "seedream", tier: "default", runwareModel: "seedream_v4" } },
+  { key: "seedream-v5-lite", label: "Seedream v5 Lite", hint: "Runware · cheapest Seedream", variant: { key: "seedream-v5-lite", provider: "seedream", tier: "default", runwareModel: "seedream_v5_lite" } },
+  { key: "qwen-image", label: "Qwen-Image", hint: "Alibaba (Runware) · cheap, good text", variant: { key: "qwen-image", provider: "seedream", tier: "default", runwareModel: "qwen_image" } },
+  { key: "wan-2.7", label: "Wan 2.7", hint: "Alibaba (Runware) · cheap, reference-aware", variant: { key: "wan-2.7", provider: "seedream", tier: "default", runwareModel: "wan_2_7" } },
+];
+
+/** Resolve a stored workspace image-model key into a leading soft-prefer variant
+ * (keeps the fallback cascade behind it). Unknown/null key → cascade default. */
+export function resolveWorkspaceImageModel(
+  key: string | null | undefined,
+): (BakeoffVariant & { soft: true }) | undefined {
+  const model = WORKSPACE_IMAGE_MODELS.find((m) => m.key === key);
+  if (!model) return undefined;
+  // Clear the variant key so status ids stay clean (single pick, not a bake-off).
+  return { ...model.variant, key: "", soft: true };
+}
+
 /** Friendly display names for cost-model ids (UI badges). */
 export const IMAGE_MODEL_LABELS: Record<string, string> = {
   "gemini-3.1-flash-image": "Nano Banana 2",
   "gemini-3-pro-image": "Nano Banana Pro",
   "gpt-image-2": "GPT Image 2",
   "bytedance:5@0": "Seedream v4",
+  "bytedance:seedream@5.0-lite": "Seedream v5 Lite",
+  "runware:108@1": "Qwen-Image",
+  "alibaba:wan@2.7-image": "Wan 2.7",
 };
 
 /** One attempt in the resilience cascade: a provider at a specific tier. */
 export interface ChainStep {
   provider: ImageProvider;
   tier: ImageTier;
+  /** For seedream/Runware steps: the specific Runware model key. */
+  runwareModel?: string;
 }
 
 // Resilience cascade, quality-first (owner decision: creative quality over
@@ -123,10 +167,10 @@ const FORCED_PROVIDER = process.env.IMAGE_PROVIDER as ImageProvider | undefined;
 
 /** Resolve the ordered list of attempts for a request. Exported for tests —
  * the chain order is a product guarantee, not an implementation detail. */
-export function resolveSceneChain(p: Pick<SceneGenParams, "provider" | "softPrefer" | "tier">): ChainStep[] {
+export function resolveSceneChain(p: Pick<SceneGenParams, "provider" | "softPrefer" | "tier" | "runwareModel">): ChainStep[] {
   const tier = p.tier ?? "default";
   if (p.provider) {
-    const pick: ChainStep = { provider: p.provider, tier };
+    const pick: ChainStep = { provider: p.provider, tier, runwareModel: p.runwareModel };
     if (!p.softPrefer) return [pick]; // forced: single attempt, no fallback
     // Soft preference: the pick leads, the full cascade stays behind it.
     return [pick, ...FALLBACK_CHAIN.filter((s) => !(s.provider === pick.provider && s.tier === pick.tier))];
@@ -135,7 +179,8 @@ export function resolveSceneChain(p: Pick<SceneGenParams, "provider" | "softPref
   return FALLBACK_CHAIN;
 }
 
-async function runProvider(provider: ImageProvider, p: SceneGenParams, tier: ImageTier): Promise<SceneGenResult> {
+async function runProvider(step: ChainStep, p: SceneGenParams): Promise<SceneGenResult> {
+  const { provider, tier } = step;
   if (provider === "gemini") {
     const model = GEMINI_MODEL[tier];
     const buffer = await generateImageGemini({ prompt: p.prompt, aspect: p.aspect, references: p.references, model });
@@ -146,12 +191,14 @@ async function runProvider(provider: ImageProvider, p: SceneGenParams, tier: Ima
     return { buffer: await generateGptImage2(p), provider, costModel: "gpt-image-2" };
   }
 
-  // seedream (Runware). Reference images passed as data URIs.
+  // seedream / other Runware models. The step carries the specific Runware model
+  // key (so a fallback step never inherits the leading pick's model). Reference
+  // images passed as data URIs.
   const refUris = (p.references ?? []).map((r) => `data:${r.mime};base64,${r.buffer.toString("base64")}`);
   const res = await generateRunware({
     prompt: p.prompt,
     negativePrompt: p.negativePrompt,
-    modelKey: "seedream_v4",
+    modelKey: step.runwareModel ?? "seedream_v4",
     aspect: p.aspect as Aspect,
     quality: "1k",
     referenceImages: refUris.length ? refUris : undefined,
@@ -183,9 +230,14 @@ export async function generateScene(p: SceneGenParams): Promise<SceneGenResult> 
   const chain = resolveSceneChain(p);
   const errors: string[] = [];
   for (const step of chain) {
-    const label = step.provider === "gemini" ? `${step.provider}/${step.tier}` : step.provider;
+    const label =
+      step.provider === "gemini"
+        ? `${step.provider}/${step.tier}`
+        : step.provider === "seedream" && step.runwareModel
+          ? `runware/${step.runwareModel}`
+          : step.provider;
     try {
-      return await withDeadline(runProvider(step.provider, p, step.tier), PROVIDER_TIMEOUT_MS, `provider "${label}"`);
+      return await withDeadline(runProvider(step, p), PROVIDER_TIMEOUT_MS, `provider "${label}"`);
     } catch (e) {
       const msg = (e as Error).message ?? String(e);
       errors.push(`${label}: ${msg.slice(0, 160)}`);

--- a/src/lib/image/runware.ts
+++ b/src/lib/image/runware.ts
@@ -15,9 +15,19 @@ export const IMAGE_MODELS: Record<string, string> = {
   nano_banana_pro: process.env.RUNWARE_MODEL_NANO_BANANA_PRO ?? "google:4@2",
   seedream_v4: process.env.RUNWARE_MODEL_SEEDREAM_V4 ?? "bytedance:5@0",
   seedream_v5_lite: process.env.RUNWARE_MODEL_SEEDREAM_V5_LITE ?? "bytedance:seedream@5.0-lite",
+  // Cheaper Chinese models (Alibaba) for cost A/B on simpler use cases; both
+  // accept reference images via inputs.referenceImages (garment/product fidelity).
+  qwen_image: process.env.RUNWARE_MODEL_QWEN_IMAGE ?? "runware:108@1",
+  wan_2_7: process.env.RUNWARE_MODEL_WAN ?? "alibaba:wan@2.7-image",
 };
 
-const NO_NEGATIVE_PROMPT = new Set(["bytedance:5@0", "bytedance:seedream@5.0-lite", "google:4@2"]);
+const NO_NEGATIVE_PROMPT = new Set([
+  "bytedance:5@0",
+  "bytedance:seedream@5.0-lite",
+  "google:4@2",
+  "runware:108@1",
+  "alibaba:wan@2.7-image",
+]);
 
 const DIM_TABLE: Record<string, Record<QualityTier, Record<Aspect, { width: number; height: number }>>> = {
   "bytedance:5@0": {
@@ -136,6 +146,56 @@ export async function generateImage(p: GenerateImageParams): Promise<GenerateIma
   );
 
   return { imageUrl, modelId, taskUUID };
+}
+
+const BG_REMOVAL_MODEL = process.env.RUNWARE_MODEL_BG_REMOVAL ?? "runware:109@1"; // RemBG 1.4
+
+export interface RemoveBackgroundResult {
+  imageUrl: string;
+  /** USD cost reported by Runware (includeCost). */
+  cost: number;
+  modelId: string;
+}
+
+/** Remove the background from an image (transparent PNG result). Input is a
+ * data URI or https URL. Callers flatten/compose the alpha as they need. */
+export async function removeBackground(image: string): Promise<RemoveBackgroundResult> {
+  const apiKey = process.env.RUNWARE_API_KEY;
+  if (!apiKey) throw new Error("RUNWARE_API_KEY missing");
+  const taskUUID = crypto.randomUUID();
+
+  const task = {
+    taskType: "removeBackground",
+    taskUUID,
+    model: BG_REMOVAL_MODEL,
+    outputType: "URL",
+    outputFormat: "PNG",
+    includeCost: true,
+    inputs: { image },
+  };
+
+  const result = await withRetry(
+    async () => {
+      const r = await fetch(RUNWARE_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+        body: JSON.stringify([task]),
+      });
+      const text = await r.text();
+      if (!r.ok) throw new Error(`runware ${r.status}: ${text.slice(0, 500)}`);
+      const body = JSON.parse(text) as {
+        data?: Array<{ taskUUID: string; imageURL?: string; cost?: number }>;
+        errors?: Array<{ message: string }>;
+      };
+      if (body.errors?.length) throw new Error(`runware error: ${body.errors.map((e) => e.message).join("; ")}`);
+      const item = body.data?.find((d) => d.taskUUID === taskUUID) ?? body.data?.[0];
+      if (!item?.imageURL) throw new Error("runware removeBackground response missing imageURL");
+      return { imageUrl: item.imageURL, cost: item.cost ?? 0 };
+    },
+    { label: `runware:bg-removal`, attempts: 4, baseDelayMs: 1500 },
+  );
+
+  return { ...result, modelId: BG_REMOVAL_MODEL };
 }
 
 export async function downloadImage(url: string): Promise<Buffer> {

--- a/src/lib/pipeline/cost-log.ts
+++ b/src/lib/pipeline/cost-log.ts
@@ -3,7 +3,7 @@ import type { CostSummary } from "./cost";
 import type { Prisma } from "@/generated/prisma/client";
 
 /** Where a batch of API cost came from. */
-export type CostSource = "generation" | "dissect" | "brand-research" | "enhance" | "editor";
+export type CostSource = "generation" | "dissect" | "brand-research" | "enhance" | "editor" | "cutout";
 
 /** Coarse provider label derived from the model/cost id (for grouping). */
 function providerOf(model: string): string {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -138,6 +138,8 @@ export const storageKeys = {
   brandScreenshot: (brandId: string, name: string) => `brands/${brandId}/screenshots/${name}.png`,
   productImage: (productId: string, imageId: string, ext: string) =>
     `products/${productId}/${imageId}.${ext}`,
+  productCutout: (productId: string, imageId: string) =>
+    `products/${productId}/${imageId}-cutout.png`,
   masterPlate: (runId: string, conceptId: string) => `runs/${runId}/plates/${conceptId}.png`,
   iteration: (runId: string, conceptId: string, iter: number) =>
     `runs/${runId}/iterations/${conceptId}-${iter}.png`,

--- a/src/trigger/creative-edit.ts
+++ b/src/trigger/creative-edit.ts
@@ -21,7 +21,7 @@ export type CreativeEditPayload =
       language: CopyLanguage;
       cause: "text_edit" | "language_switch";
     }
-  // FREE recomposite of an extra aspect — no credits debited, never refunded.
+  // Native render of an extra aspect (image-model call) — paid like a regen.
   | { kind: "render_aspect"; creativeId: string; workspaceId: string; aspect: SceneAspect };
 
 /**
@@ -44,7 +44,7 @@ export const creativeEdit = task({
       payload.kind === "regen_instruction"
         ? await applyRegenInstruction(creative, payload.workspaceId, payload.instruction)
         : payload.kind === "render_aspect"
-          ? await applyRenderAspect(creative, payload.aspect)
+          ? await applyRenderAspect(creative, payload.aspect, payload.workspaceId)
           : await applyBakedTextSwap(
             creative,
             payload.workspaceId,
@@ -63,9 +63,9 @@ export const creativeEdit = task({
   },
   catchError: async ({ payload, error }) => {
     // apply* never throw — reaching here means we crashed before the edit ran
-    // (e.g. creative lookup), so the action's debit must be returned.
+    // (e.g. creative lookup), so the action's debit must be returned. Every edit
+    // kind (incl. render_aspect, now a paid native render) is debited up front.
     logger.error("creative edit crashed", { creativeId: payload.creativeId, error: (error as Error).message });
-    if (payload.kind === "render_aspect") return; // free edit — nothing was debited
     await grantCredits({
       workspaceId: payload.workspaceId,
       amount: CREDIT_COSTS.regenInstruction,

--- a/src/trigger/generation-run.ts
+++ b/src/trigger/generation-run.ts
@@ -1,7 +1,7 @@
 import { task, tasks, logger, metadata } from "@trigger.dev/sdk";
 import { prisma } from "@/lib/db";
 import { CREDIT_COSTS, LIMITS } from "@/lib/ai/models";
-import { generateScene, variantsForPref, BAKEOFF_VARIANTS, type BakeoffVariant, type SceneAspect } from "@/lib/image/provider";
+import { generateScene, variantsForPref, resolveWorkspaceImageModel, BAKEOFF_VARIANTS, type BakeoffVariant, type SceneAspect } from "@/lib/image/provider";
 import { downloadFromStorage, storageKeys, uploadBuffer } from "@/lib/storage";
 import { reconcileRunRefund } from "@/lib/credits";
 import { assembleOccasionBrief } from "@/lib/pipeline/brief";
@@ -88,15 +88,23 @@ export const generationRun = task({
     }
     const tracker = new CostTracker();
 
-    // Shared assets
+    // Shared assets. Prefer the cached background-removed cutout (clean white
+    // packshot, made once at upload by product-cutout) over the raw photo —
+    // cleaner reference, no per-run cleanup cost.
     const productImage = run.product?.images[0] ?? null;
-    const refBuffer = productImage ? await downloadFromStorage(productImage.storageKey) : null;
+    const refBuffer = productImage
+      ? await downloadFromStorage(productImage.cutoutKey ?? productImage.storageKey)
+      : null;
+    const refMime = productImage?.cutoutKey ? "image/png" : (productImage?.mimeType ?? "image/png");
     // Additional product angles (multi-reference fidelity) — downloaded in parallel.
     const extraRefs: Array<{ buffer: Buffer; mime: string }> = (
       await Promise.all(
         (run.product?.images.slice(1) ?? []).map(async (img) => {
           try {
-            return { buffer: await downloadFromStorage(img.storageKey), mime: img.mimeType };
+            return {
+              buffer: await downloadFromStorage(img.cutoutKey ?? img.storageKey),
+              mime: img.cutoutKey ? "image/png" : img.mimeType,
+            };
           } catch (e) {
             logger.warn("extra product ref download failed", { error: (e as Error).message });
             return null;
@@ -120,12 +128,12 @@ export const generationRun = task({
     // accounts get editorial campaign direction, everyone else gets the clean
     // garment-forward showcase. Fetched once here so BOTH direct and guided
     // runs inherit it (the brief-level editorial paragraph below reuses it).
-    const workspace = await prisma.workspace.findUnique({ where: { id: run.workspaceId }, select: { type: true } });
+    const workspace = await prisma.workspace.findUnique({ where: { id: run.workspaceId }, select: { type: true, imageModel: true } });
     const onModelDirection: OnModelDirection =
       workspace?.type === "FASHION_EDITORIAL" ? "editorial" : "catalog";
 
     const ctx: ConceptCtx = {
-      runId, run, refBuffer, extraRefs, logoBuffer, logoAssetKey: logoAsset?.storageKey,
+      runId, run, refBuffer, refMime, extraRefs, logoBuffer, logoAssetKey: logoAsset?.storageKey,
       aspects, masterAspect, language, intel, studioComposite, tracker,
       onModel, modelBuffer, modelMime: run.aiModel?.mimeType ?? "image/png",
       onModelDirection,
@@ -133,11 +141,15 @@ export const generationRun = task({
     };
 
     // Render variants: bake-off = the full admin lineup (forced, no fallback);
-    // otherwise the user's model pick — single (soft, fallback kept) or
-    // "compare" (both premium models, forced, double credits already debited).
+    // else the workspace image-model setting (super-admin-chosen, soft-prefer);
+    // else the legacy per-run pref (single soft pick or "compare"); else the
+    // default cascade.
+    const wsModelVariant = resolveWorkspaceImageModel(workspace?.imageModel);
     const variants: Array<(BakeoffVariant & { soft?: boolean }) | undefined> = run.bakeoff
       ? BAKEOFF_VARIANTS
-      : variantsForPref(run.imageModelPref);
+      : wsModelVariant
+        ? [wsModelVariant]
+        : variantsForPref(run.imageModelPref);
     const ctxFor = (v: (BakeoffVariant & { soft?: boolean }) | undefined): ConceptCtx =>
       v ? { ...ctx, forced: v, variantTag: v.key ? `-${v.key}` : "" } : ctx;
 
@@ -198,9 +210,14 @@ export const generationRun = task({
       // ---- Stage 2: evidence-grounded senior-CD concept briefs ----
       await setStatus(runId, "CONCEPTING");
       const brandPalette = [run.brand.primaryColorHex, ...run.brand.accentColorsHex].filter((h): h is string => Boolean(h));
+      // Multi-pose on-model: ONE concept (same model + garment) rendered across
+      // the selected poses — the poses are the variation axis, not the concepts.
+      // Every other run generates one concept per requested option.
+      const multiPose = onModel && run.modelPoses.length > 0;
+      const conceptTarget = multiPose ? 1 : Math.min(run.conceptCount, LIMITS.maxConceptsPerRun);
       let concepts = await generateConcepts(
         occasionBrief,
-        Math.min(run.conceptCount, LIMITS.maxConceptsPerRun),
+        conceptTarget,
         tracker,
         brandPalette.length ? brandPalette : undefined,
         intelToEvidenceBlock(brandIntel),
@@ -231,11 +248,17 @@ export const generationRun = task({
         }).catch(() => {});
       }
 
-      // One work item per concept — times the variant lineup on bake-off runs.
-      // Status ids stay `idx` for normal runs, `idx-variantKey` for bake-off.
-      const queue = concepts.flatMap((c, i) =>
-        variants.map((v) => ({ concept: c, idx: i, variant: v })),
-      );
+      // Work items. Normal runs: one per concept, times the variant lineup on
+      // bake-off runs. Multi-pose on-model: one per selected pose (all sharing
+      // the single concept), so `idx` is the pose index and each carries its
+      // pose override for buildOnModelPrompt.
+      const queue = multiPose
+        ? run.modelPoses.flatMap((pose, i) =>
+            variants.map((v) => ({ concept: concepts[0], idx: i, variant: v, pose })),
+          )
+        : concepts.flatMap((c, i) =>
+            variants.map((v) => ({ concept: c, idx: i, variant: v, pose: undefined as string | undefined })),
+          );
       await updatePipeline(runId, (p) => {
         p.concepts = concepts;
         p.conceptStatus = Object.fromEntries(
@@ -248,10 +271,10 @@ export const generationRun = task({
       await setStatus(runId, "RENDERING");
       const workers = Array.from({ length: Math.min(LIMITS.maxConcurrentConcepts, queue.length) }, async () => {
         while (queue.length) {
-          const { concept, idx, variant } = queue.shift()!;
+          const { concept, idx, variant, pose } = queue.shift()!;
           const cid = `${idx}${variant ? `-${variant.key}` : ""}`;
           try {
-            await processConcept(ctxFor(variant), concept, idx);
+            await processConcept({ ...ctxFor(variant), poseOverride: pose }, concept, idx);
             succeeded += 1;
             await updatePipeline(runId, (p) => { p.conceptStatus![cid] = "done"; });
           } catch (e) {
@@ -351,6 +374,8 @@ interface ConceptCtx {
   runId: string;
   run: RunWithRels;
   refBuffer: Buffer | null;
+  /** Mime of refBuffer (PNG when it's the cached cutout, else the original photo's). */
+  refMime: string;
   /** Additional product angles (multi-reference fidelity), excluding refBuffer. */
   extraRefs: Array<{ buffer: Buffer; mime: string }>;
   logoBuffer?: Buffer;
@@ -371,6 +396,8 @@ interface ConceptCtx {
   forced?: BakeoffVariant & { soft?: boolean };
   /** Bake-off: suffix keeping storage keys / status ids unique per variant. */
   variantTag: string;
+  /** Multi-pose on-model: the pose for THIS work item (overrides run.modelPose). */
+  poseOverride?: string;
 }
 
 /** How the headline got onto this creative. Always overlay = canvas-composited
@@ -401,7 +428,7 @@ interface PlateResult {
 async function generatePlate(ctx: ConceptCtx, concept: CreativeConcept, aspect: SceneAspect): Promise<PlateResult> {
   // Variant pin: bake-off forces the provider (no fallback — a failed variant
   // is a data point); a user model pick prefers it but keeps the chain (soft).
-  const model = { provider: ctx.forced?.provider, tier: ctx.forced?.tier, softPrefer: ctx.forced?.soft };
+  const model = { provider: ctx.forced?.provider, tier: ctx.forced?.tier, softPrefer: ctx.forced?.soft, runwareModel: ctx.forced?.runwareModel };
   if (ctx.onModel) {
     // ON_MODEL: fuse the AI model (image 1) + the real garment (image 2).
     // Missing references are a hard error — silently falling through to a
@@ -412,13 +439,13 @@ async function generatePlate(ctx: ConceptCtx, concept: CreativeConcept, aspect: 
     }
     const refs = [
       { buffer: ctx.modelBuffer, mime: ctx.modelMime },
-      { buffer: ctx.refBuffer, mime: ctx.run.product.images[0].mimeType },
+      { buffer: ctx.refBuffer, mime: ctx.refMime },
     ];
     const prompt = buildOnModelPrompt({
       concept,
       aspect,
       garmentPrompt: ctx.run.product?.dissectionPrompt,
-      pose: ctx.run.modelPose,
+      pose: ctx.poseOverride ?? ctx.run.modelPose,
       direction: ctx.onModelDirection,
       plain: ctx.run.brandingMode === "PLAIN",
     });
@@ -440,7 +467,7 @@ async function generatePlate(ctx: ConceptCtx, concept: CreativeConcept, aspect: 
     // and pack-fidelity QA below verifies the label against the reference.
     const hasProduct = Boolean(ctx.refBuffer);
     const refs = hasProduct && ctx.run.product?.images[0]
-      ? [{ buffer: ctx.refBuffer!, mime: ctx.run.product.images[0].mimeType }, ...ctx.extraRefs]
+      ? [{ buffer: ctx.refBuffer!, mime: ctx.refMime }, ...ctx.extraRefs]
       : undefined;
     const prompt = buildScenePassPrompt({
       concept,
@@ -476,7 +503,7 @@ async function ensurePackFidelity(
     prompt: string;
     aspect: SceneAspect;
     refs: Array<{ buffer: Buffer; mime: string }>;
-    model: { provider?: BakeoffVariant["provider"]; tier?: BakeoffVariant["tier"]; softPrefer?: boolean };
+    model: { provider?: BakeoffVariant["provider"]; tier?: BakeoffVariant["tier"]; softPrefer?: boolean; runwareModel?: string };
     stage: string;
   },
 ): Promise<{ gen: Awaited<ReturnType<typeof generateScene>>; fidelityQa: NonNullable<PlateResult["fidelityQa"]> }> {
@@ -493,6 +520,7 @@ async function ensurePackFidelity(
       provider: opts.model.provider,
       tier: opts.model.tier,
       softPrefer: opts.model.softPrefer,
+      runwareModel: opts.model.runwareModel,
     });
     ctx.tracker.addImage(gen.costModel, opts.stage);
     verdict = await checkPackFidelity({ render: gen.buffer, reference: ctx.refBuffer!, tracker: ctx.tracker });
@@ -512,7 +540,7 @@ async function ensureOnModelFidelity(
     prompt: string;
     aspect: SceneAspect;
     refs: Array<{ buffer: Buffer; mime: string }>;
-    model: { provider?: BakeoffVariant["provider"]; tier?: BakeoffVariant["tier"]; softPrefer?: boolean };
+    model: { provider?: BakeoffVariant["provider"]; tier?: BakeoffVariant["tier"]; softPrefer?: boolean; runwareModel?: string };
   },
 ): Promise<{ gen: Awaited<ReturnType<typeof generateScene>>; fidelityQa: NonNullable<PlateResult["fidelityQa"]> }> {
   const [modelRef, garmentRef] = opts.refs;
@@ -531,6 +559,7 @@ async function ensureOnModelFidelity(
       provider: opts.model.provider,
       tier: opts.model.tier,
       softPrefer: opts.model.softPrefer,
+      runwareModel: opts.model.runwareModel,
     });
     ctx.tracker.addImage(gen.costModel, "on-model");
     verdict = await check(gen.buffer);
@@ -570,6 +599,9 @@ async function processConcept(ctx: ConceptCtx, concept: CreativeConcept, idx: nu
       concept: {
         ...concept,
         typographyMode,
+        // The pose this creative was rendered with (on-model), so an editor
+        // aspect re-render reproduces the SAME pose natively.
+        ...(ctx.onModel ? { pose: ctx.poseOverride ?? ctx.run.modelPose ?? undefined } : {}),
         // Per-aspect plate keys so the editor re-composes each aspect from its
         // own native plate (scenePlateKey kept = the master plate for legacy).
         aspectPlateKeys,
@@ -629,14 +661,14 @@ async function processDirect(ctx: ConceptCtx): Promise<void> {
       });
       let gen = await generateScene({
         prompt, aspect, references: refs,
-        provider: ctx.forced?.provider, tier: ctx.forced?.tier,
+        provider: ctx.forced?.provider, tier: ctx.forced?.tier, softPrefer: ctx.forced?.soft, runwareModel: ctx.forced?.runwareModel,
       });
       ctx.tracker.addImage(gen.costModel, "direct");
       let fidelityQa: PlateResult["fidelityQa"];
       if (refs) {
         ({ gen, fidelityQa } = await ensurePackFidelity(ctx, {
           gen, prompt, aspect, refs,
-          model: { provider: ctx.forced?.provider, tier: ctx.forced?.tier },
+          model: { provider: ctx.forced?.provider, tier: ctx.forced?.tier, softPrefer: ctx.forced?.soft, runwareModel: ctx.forced?.runwareModel },
           stage: "direct",
         }));
       }

--- a/src/trigger/product-cutout.ts
+++ b/src/trigger/product-cutout.ts
@@ -1,0 +1,62 @@
+import { task, logger } from "@trigger.dev/sdk";
+import sharp from "sharp";
+import { prisma } from "@/lib/db";
+import { downloadFromStorage, storageKeys, uploadBuffer } from "@/lib/storage";
+import { removeBackground, downloadImage, bufferToDataUri } from "@/lib/image/runware";
+import { persistCost } from "@/lib/pipeline/cost-log";
+
+/**
+ * One-time background removal per product image. Runs at upload so generation
+ * runs reuse the cached cutout (white-flattened packshot PNG) as their product
+ * reference instead of paying/waiting for any per-run cleanup. Idempotent:
+ * only images without a cutoutKey are processed, so re-triggering is free.
+ */
+export const productCutout = task({
+  id: "product-cutout",
+  maxDuration: 300,
+  run: async (payload: { productId: string }) => {
+    const images = await prisma.productImage.findMany({
+      where: { productId: payload.productId, cutoutKey: null },
+      include: { product: { select: { brand: { select: { workspaceId: true } } } } },
+    });
+    if (!images.length) return { processed: 0, cached: true };
+
+    let processed = 0;
+    let totalUSD = 0;
+    let costModel = "";
+    for (const img of images) {
+      try {
+        const original = await downloadFromStorage(img.storageKey);
+        const removed = await removeBackground(bufferToDataUri(original, img.mimeType));
+        const transparent = await downloadImage(removed.imageUrl);
+        // Flatten onto white: image models handle a clean studio packshot far
+        // better than alpha transparency, and it doubles as an e-comm listing look.
+        const cutout = await sharp(transparent).flatten({ background: "#ffffff" }).png().toBuffer();
+        const key = storageKeys.productCutout(img.productId, img.id);
+        await uploadBuffer(key, cutout, "image/png");
+        await prisma.productImage.update({ where: { id: img.id }, data: { cutoutKey: key } });
+        processed += 1;
+        totalUSD += removed.cost;
+        costModel = removed.modelId;
+      } catch (e) {
+        // A missing cutout is never fatal — generation falls back to the
+        // original photo; the next trigger retries this image (cutoutKey null).
+        logger.warn("cutout failed for image", { imageId: img.id, error: (e as Error).message });
+      }
+    }
+
+    if (processed > 0) {
+      await persistCost({
+        summary: {
+          totalUSD, llmUSD: 0, imageUSD: totalUSD, imageCount: processed,
+          llm: [],
+          images: Array.from({ length: processed }, () => ({ stage: "cutout", model: costModel, usd: totalUSD / processed })),
+        },
+        source: "cutout",
+        workspaceId: images[0].product.brand.workspaceId,
+      });
+    }
+    logger.info("cutouts complete", { productId: payload.productId, processed, totalUSD });
+    return { processed, cached: false };
+  },
+});

--- a/tasks/todo-r4-archive.md
+++ b/tasks/todo-r4-archive.md
@@ -1,0 +1,254 @@
+# Round 4 — Productization: dev script, pipeline quality, account types, marketing, AI bot (2026-07-11) — DONE (all R4 items ✅, gate passed 2026-07-11)
+
+Execution order: R4.1 → R4.5 → R4.4 → R4.2 → R4.3
+(pipeline before marketing/bot so copy + bot knowledge describe FINAL capabilities; account types before marketing because login-only changes login copy.)
+
+## R4.1 `npm run dev` runs Trigger.dev too — ✅ DONE
+- [x] `dev` = concurrently(next dev, trigger dev); `dev:next`/`dev:trigger` standalone
+- [x] devDeps: concurrently@^10, trigger.dev@4.4.6 (pinned = SDK version); allowScripts approvals for CLI esbuild/@depot postinstalls
+- [x] Verified 25s smoke run; zero prod impact (Vercel runs `next build`; Trigger deploys via `trigger.dev deploy`)
+- [x] DEVLOG entry
+
+## R4.5 Pipeline review + quality-first hardening
+- [ ] Fallback chain → tiered steps in src/lib/image/provider.ts:
+      **Nano Banana Pro (gemini hero) → gpt-image-2 → Nano Banana 2 (gemini default) → Seedream** (user-specified order)
+      — single reusable FALLBACK_CHAIN of {provider, tier} consumed by generateScene; call-site API unchanged
+- [ ] Default render tier → hero / NB Pro (quality > cost, per user)
+- [ ] BRIEF VALIDATOR stage: semantic QA of concepts (product/brand/occasion consistency) + one repair round, between CONCEPTING and RENDERING
+- [ ] PROMPT ENHANCER stage in-pipeline for image prompts (enhance-prompt.ts is UI-only today)
+- [ ] Fail-open QA gates (pack-qa, placement-qa): add one extra quality-critical retry
+- [ ] Tests: chain order, validator schema; tsc + vitest green
+- [ ] UI: NB Pro default pref; label fallback-used
+- [ ] DEVLOG entry
+
+## R4.4 3 account types + workspaces + login-only + invites
+- [ ] schema: enum WorkspaceType { FMCG_PRODUCT, APPAREL_ON_MODEL, FASHION_EDITORIAL } + Workspace.type; Creative.deletedAt
+- [ ] Thread type → AuthContext + generation defaults (FMCG: SKU + festival/theme/custom, EXACT_PRODUCT/IN_SCENE; APPAREL: ON_MODEL standard; FASHION: ON_MODEL editorial-campaign prompt flavor)
+- [ ] Login-only: signIn callback denies unknown emails (no User + no PENDING invite) → "invite required" page; remove auto-workspace-create; fix login caption
+- [ ] Invite email: src/lib/email.ts (nodemailer GMAIL_* pattern from send-enquiry) sent from inviteMember
+- [ ] Workspace setup + creative soft-delete script (DESTRUCTIVE — only after explicit user confirm)
+- [ ] Re-run refreshBrandIntel per workspace after setup
+- [ ] Additive prisma migration
+- [ ] DEVLOG entries
+
+## R4.2 Marketing redesign (design-taste-frontend skill)
+- [ ] Read SKILL.md lines 509+ first
+- [ ] Scope: src/app/(marketing)/* + src/components/marketing/* + mk-tokens in globals.css
+- [ ] Remove ALL 44 user-facing em-dashes (rewrite sentences, not mechanical swaps)
+- [ ] Studio copy = real capabilities (overlay compositor, NOT "typography set into the image"; verify 45-occasions count, credits, languages, refund + QA claims)
+- [ ] Skill hard rules: hero discipline, eyebrow cap, section variety, CTA dedup, image strategy
+- [ ] DEVLOG entry
+
+## R4.3 AI bot (Synerix-scoped, Gemini Flash)
+- [ ] Vercel AI SDK (`ai` + `@ai-sdk/google`, already installed): streamText, `gemini-flash-latest`; env GOOGLE_GENERATIVE_AI_API_KEY (user adds)
+- [ ] src/app/api/chat/route.ts guardrails: scoped system prompt + embedded knowledge base, topic refusal, input/output caps, message-count cap, rate limit (src/lib/rate-limit.ts), no tools, no prompt disclosure
+- [ ] Floating chat widget in (marketing) layout
+- [ ] DEVLOG entry
+
+## Review (2026-07-11)
+- R4.1 ✅ dev script (verified via 25s smoke run)
+- R4.5 ✅ tiered cascade NB Pro → GPT → NB2 → Seedream (resolveSceneChain, 4 new tests); brief validator + repair (sonnet judge, opus repair, fail-open); batch prompt enhancer (opus, guarded); pack QA 2 retries; placement QA 2 runner-ups; fallback badge on single picks
+- R4.4 ✅ code + DB EXECUTED (user confirmed 2×): migration applied; 39 creatives soft-deleted; FMCG Creative Studio / Apparel Studio / Fashion Editorial Studio created (owner dev@synerix.local, god-view covers all); invite-only auth + /request-access; invite emails; soft-delete filters on 9 reads; FASHION_EDITORIAL brief flavor
+- R4.2 ✅ marketing polish: truthful Studio copy (overlay-first, invite-only), zero em/en dashes, eyebrow rationing 6→2/page, hero discipline, bento features, CTA dedup. Verified: build + lint + tsc clean
+- R4.3 ✅ chat bot: /api/chat (AI SDK v6 + gemini-flash-latest, zod validation, rate limit 10/min, 500-token cap, scope-locked system prompt, 503 w/o key) + mk-styled floating widget in (marketing) layout
+- Gate: tsc 0 · 49/49 vitest · eslint clean · next build clean
+- User TODOs: add GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLIENT_ID/SECRET, GMAIL_USERNAME/PASSWORD, SUPER_ADMIN_EMAIL; sign in once w/ Google before running setup script; `npx trigger.dev deploy` when ready
+
+---
+
+# Round 3 — Quality reset after floating-pack run (2026-07-05) — ✅ EXECUTED
+
+User's verdict on run 2: pack floating mid-air (crude cut-out paste), dull scene, still blue CTA.
+Directive: quality over cost; latest opus/sonnet for concepting; NB Pro / GPT-Image-2 for images;
+user-selectable "both" for comparison.
+
+- [x] R3.1 Concepts → claude-opus-4-8 (enhance rides same slot); research → claude-sonnet-5;
+      pricing table updated; live smoke test passed on both
+- [x] R3.2 Cut-out paste RETIRED: EXACT_PRODUCT renders in-scene on premium model + pack-fidelity QA
+      (label verified vs reference, one strict retry); concepts.ts stages pack prominent + label-readable
+      instead of forcing product_hero; cutout.ts left in place but unused (deletion not approved)
+- [x] R3.3 Image model picker in create form (all users): Nano Banana Pro (default) / GPT Image 2 /
+      Both — compare (2× credits, per-option side-by-side with model badges on the run page)
+- [x] R3.4 Single picks soft-prefer (fallback chain kept); compare/bake-off hard-forced;
+      GenerationRun.imageModelPref (+migration); refund math unchanged (queue doubles with cost)
+- [x] R3.5 Editor paid edits → hero tier (same premium bar as generation)
+
+Gate: tsc 0 · 36/36 vitest · lint 0 errors · build clean · live opus/sonnet smoke OK.
+**User TODOs:** re-test the same Gillco brief (pick "Both — compare" to judge NB Pro vs GPT-Image-2);
+`npx trigger.dev deploy`; re-ingest Gillco (or set brand colors in Brand Kit) to kill the blue CTA;
+note per-run API cost now higher (~$0.15-0.30 concepting + $0.134/img NB Pro) — visible in /admin/costs.
+
+---
+
+# Round 2 — Quality/Perf/Content fixes (2026-07-04) — ✅ EXECUTED 2026-07-05
+
+User's 7 concerns from first real run (Gillco "Punjabi Poori Atta", 9:16, EXACT_PRODUCT, Friendship Day).
+Root causes investigated (4 subagent audits + DB inspection of run 82e64023). Plan below; verify per batch:
+`npx tsc --noEmit` + `npm test` + `npm run build` + touched flow.
+
+## Batch 1 — Output quality: overlay typography (user items 2)
+- [x] 1a. Local-contrast enforcement: sample plate pixels under each text layer + CTA pill in
+      composeAllAspects; WCAG ratio < threshold → remap colorRole to ink/white or luminance-shifted
+      variant (new helper in src/lib/composition/analyze.ts)
+- [x] 1b. Un-dead the `dominant` param in resolveRoles (src/lib/composition/color.ts:24): accent too
+      close in hue/luminance to a dominant plate color → substitute
+- [x] 1c. Empty-band anchoring: analyzeRegions 3 fixed thirds → 6–8 bands returning calmest band's
+      y-range; anchor copy block into it; on 9:16 drop safeBottom 400 → ~120 when bottom band calm
+- [x] 1d. Fix 9:16 band classifier (score.ts:72-74): classify by headline center vs thirds
+- [x] 1e. Placement QA hardening: per-layer verdict schema (eyebrow/headline/body/cta/logo ×
+      overlaps/lowContrast); retry must differ in archetype; double-fail → render guaranteed-legible
+      fallback (clean-bottom, all-ink, scrim 0.75) instead of shipping the failure
+- [x] 1f. Wire concept typographySpec zone (generated + reserved in plate, currently discarded) into
+      selectTemplates signals
+
+## Batch 2 — Output quality: exact-pack fidelity + brand palette (user items 3 + root of 2's blue)
+- [x] 2a. Thread fidelityMode into generateConcepts; EXACT_PRODUCT → force/strongly-prefer
+      productPlacement=product_hero (composite path = real pack pixels)
+- [x] 2b. Pack-region vision QA for residual in-scene renders in EXACT_PRODUCT: compare rendered pack
+      vs reference photo; mismatch → re-render once or demote to composite fallback
+- [x] 2c. Brand ingest palette hygiene: prompt prefers logo/brand-mark colors, rejects generic UI
+      blues; validate against extracted logo palette before persisting primaryColorHex/accentColorsHex
+- [x] 2d. (decide) hero tier (NB Pro) for in-scene EXACT_PRODUCT renders — 2.2× image cost on those
+
+## Batch 3 — Performance (user item 4)
+- [x] 3a. db.ts:23 pool max 1 → 5 (unblocks all Promise.all query fan-outs)
+- [x] 3b. ensureMembership early-return when no invites + memberships exist (−2 queries/request)
+- [x] 3c. Cache signed URLs: unstable_cache around getSignedThumbUrls/getSignedUrls, revalidate 3300s
+- [x] 3d. Remove double render: drop router.refresh() from editor mutate() success (actions already
+      revalidatePath)
+- [x] 3e. Studio polling: refresh only on realtime done-increment/terminal; interval = fallback only
+- [x] 3f. renderNewAspect (size generation) → existing Trigger.dev pending-edit path
+- [x] 3g. Drop layout's duplicate memberships query (expose from requireAuth)
+
+## Batch 4 — Per-run cost dashboard (user item 1)
+- [x] 4a. Runs list page: every generation run + credits debited + USD total (ApiCostLog has
+      runId+stage already — pure UI). DECIDE: super-admin only (raw USD = internal margin data) vs
+      workspace-visible
+- [x] 4b. Run drilldown: per-stage cost table (concepts/enhance/image/placement-qa/…), per-source
+      totals incl. editor/dissect/brand-research
+
+## Batch 5 — Festival picker in create form (user item 5)
+- [x] 5a. Occasion selector inside studio create form (upcoming calendar entries + custom brief),
+      not only via home/calendar deep-link ?occasion=
+
+## Batch 6 — Marketing site content + responsive (user item 6)
+- [x] 6a. Home: consulting-led hero; restore old 6-service catalogue (data/features.ts base,
+      enriched in new concrete voice); restore Why-Us pillars + real testimonial (verify facts);
+      stats row → verifiable facts; de-festival the Studio band
+- [x] 6b. /consulting: expand 4 → 6 service areas; add Who-we-are (25+ yrs credential — verify);
+      keep engagement cadence + free-first-conversation
+- [x] 6c. /synerix-studio: kill over-claims ("agency-grade", "pixel-faithful", "never drawn wrong",
+      "swear an agency made", "45+"→"45"); lead with your-product-your-brand; festivals = one bullet;
+      foreground true differentiators (refunds, 4 concepts, 4 languages, human activation)
+- [x] 6d. Responsive nits: admin leads grid-cols-3 → responsive; admin tabs overflow-x-auto;
+      create-form/editor unprefixed grids checked at 320px
+- [x] 6e. Unify WhatsApp number to env WHATSAPP_NUMBER (3 hardcoded sites); metadata de-hype
+- [x] 6f. Verify CREDIT_COSTS.perConcept + LIMITS.maxConceptsPerRun match pricing copy
+
+## Batch 7 — Onboarding workspace profile (user item 7)
+- [x] 7a. Add 2–3 skippable onboarding questions: industry/category, primary use case, sells via
+      (marketplace/D2C/offline); store on Workspace
+- [x] 7b. Profile drives surface: hide/deprioritize Models nav + on-model mode where irrelevant
+      (e.g. packaged-foods brand), default fidelity mode, calendar relevance ordering
+
+## Round 2 Review (2026-07-05)
+
+Final gate: `tsc --noEmit` 0 · 36/36 vitest · lint 0 errors (4 pre-existing warnings) ·
+`next build` clean. New migration `20260704202919_add_workspace_profile` applied to dev DB (additive).
+DEVLOG entries per batch. Decisions as approved: cost dashboard super-admin only; exact-pack forces
+product_hero + pack QA; hero tier NOT enabled (revisit post bake-off).
+
+**Deviations / notes:**
+- 2b "demote to composite fallback" → implemented as one strict re-render + verdict in critic
+  (crude center-paste composite onto an already-staged scene looks sticker-like; review gate + verdict
+  is the better failure mode).
+- 1c safeBottom drops to 160 (not 120) when the 9:16 bottom band is calm — keeps motto/contact clear.
+- 6a testimonial: the "Utkarsh Singh @AccioJob" quote in the old repo was a commented-out TEMPLATE
+  placeholder (praising "Monkster"), never a real client quote → REMOVED from both pages; a marked
+  slot comment remains. Add only real verified quotes.
+- 4: an older uncommitted aggregate-only /admin/costs page existed; replaced by the run-centric
+  dashboard (spec matched your ask). Old aggregate view not preserved.
+- 7b calendar-relevance ordering + default-fidelity by profile deferred (profile data must exist first);
+  on-model is hidden by product category (APPAREL) in the create form — stronger signal than profile.
+- Incident: a subagent's `git stash` transiently reverted uncommitted `prisma/schema.prisma` to HEAD;
+  fully restored from the generated client's embedded inlineSchema + verified (`prisma validate`, 24 models).
+
+**User TODOs:**
+1. Test flows, then commit + push yourself (nothing committed). Suggested first test: repeat the
+   Gillco Friendship-Day 9:16 EXACT_PRODUCT run and compare against the old output.
+2. Deploy trigger tasks (`npx trigger.dev deploy`) — generation-run, brand-ingest, creative-edit all changed.
+3. Re-ingest the Gillco brand (or manually set brand colors) so the logo-grounded palette replaces the blue.
+4. Verify consulting-page claims you alone can confirm: "25+ years", "run, grown and rescued real businesses".
+5. Set `WHATSAPP_NUMBER` env (falls back to +91 92164 92174).
+6. Sentry TODOs from round 1 still open (`npm i @sentry/node`, set DSNs).
+
+---
+
+# Productionize — Synerix Studio (2026-07-02)
+
+Decisions locked via grill session. I edit only — user tests, commits, pushes.
+Verify after every batch: `npx tsc --noEmit` + `npm test` + `npm run build` + touched flow.
+
+## Batch A — Security (highest risk, safe fixes) ✅ verified (tsc clean, 36/36 tests)
+- [x] A1. Delete `src/app/api/_debug-db/route.ts` (public DB-info leak; no caller in src)
+- [x] A2. `GET /api/health` — public but leak-free (ok/503 only) + rate-limited; deviation from "auth-gated": uptime monitors can't hold sessions, nothing sensitive returned
+- [x] A3. `src/lib/rate-limit.ts` — in-memory sliding-window limiter (per-instance on serverless; fine at current traffic)
+- [x] A4. `/api/check-user` → boolean-only (`hasTakenTest` + copy, no score/date), rate-limited 20/10min; wizard's orphaned score/date display + type fields removed; same oracle neutered in send-test-report 409 branch
+- [x] A5. Rate-limited `/api/send-enquiry` (5/h/IP) + `/api/send-test-report` (3/h/IP)
+- [x] A6. No change — 50mb already right-sized: comment in next.config.ts covers the legit 5×8MB product-form max with margin
+
+## Batch B — Cleanup + docs ✅ verified (tsc clean, 36/36 tests)
+- [x] B1. Deleted `legacy/`, `graphify-out/` (+ gitignore), spikes except `FINDINGS.md`, 5 `scripts/_*.mjs` debug scripts
+- [x] B2. Removed `satori` + `@resvg/resvg-js` deps (only non-spike match was a comment)
+- [x] B3. Removed `flux_2_pro`; `deriveProductPlacement` stub replaced by wiring real `concept.productPlacement` → `selectTemplates` (root-cause fix); `IMAGE_MODEL_SLOTS` restructure deferred to C1; `seedream_v5_lite` kept (not approved for removal)
+- [x] B4. Sharing copy fixed in editor + preview-stage
+- [x] B5. `CONTEXT.md` trued: overlay-first typography, env-driven model tier, bake-off note
+- [x] B6. `DEVLOG.md` created (committed mode — default chosen while user AFK, reversible) + discipline snippet in project CLAUDE.md
+
+## Batch C — Model config unification + admin bake-off ✅ verified (tsc clean, 36/36 tests, migration applied)
+- [x] C1. Editor paid edits migrated to `generateScene` router (env-driven default = NB2 flash via existing `GEMINI_IMAGE_MODEL_FAST`/`IMAGE_PROVIDER`, fallback chain, + editor costs now land in ApiCostLog via new "editor" source); `IMAGE_MODEL_SLOTS` deleted
+- [x] C2. Bake-off: `GenerationRun.bakeoff` + `Creative.imageModel` columns (migration `20260702105109`); super-admin toggle in create form; fan-out concepts × {nb2, nb-pro, gpt-image-2, seedream} with forced provider (no fallback); zero debit + refund guard; model labels on run rail
+- [x] C3. Normal runs untouched: single variant, fallback chain intact
+
+## Batch D — Overlay placement QA ✅ verified (tsc clean, 36/36 tests)
+- [x] D1. `placement-qa.ts` vision check on composited pixels; fail → re-composite with runner-up template, re-check once, fail-open; verdict stored in `critic.placementQa`; cost-tracked
+- [x] (F3 pulled forward) `conceptStatus` wired: failed work items render as distinct slots with error tooltip; PARTIAL runs now explain themselves
+
+## Batch E — Editor async migration ✅ verified (tsc clean, 36/36 tests)
+- [x] E1. `src/lib/editor/paid-edits.ts` + `creative-edit` task; debit stays sync in actions, refunds live next to failures, no double-refund paths
+- [x] E2. Editor watches the task via useRealtimeRun (scoped 15-min token, 60s-refresh fallback); per-lane busy states preserved via derived consts
+
+## Batch F — UX polish bundle ✅ (agent-implemented, verified: tsc 0, 36/36, lint 0 new)
+- [x] F1. Library pagination (?page/?rpage + counts + Prev/Next, tab preserved)
+- [x] F2. `AutoRefresh` component on Products + Models lists (4s while non-terminal)
+- [x] F3. Done in Batch C/D pass (failed-slot display on run canvas)
+- [x] F4. ProductActions toasts on delete/re-analyze results
+- [x] F5. Brand-kit client form wrapper: pending + toasts (orphaned void wrapper removed)
+- [x] F6. Onboarding ingest: always-visible "fill in manually" escape (chose simpler variant over 60s timer)
+- [x] F7. Dashboard checklist: real done states + destructive failed-ingest hint
+- [x] F8. `addProductImages` action (reuses createProduct validation, 5-cap, no re-dissect — dissection reads primary image only) + add-photos tile on detail page
+- [x] F9. Model delete → Dialog confirm
+
+## Batch G — Ops ✅ verified (full gate: tsc 0, 36/36 tests, lint 0 errors, build clean)
+- [x] G1. Sentry: instrumentation.ts + instrumentation-client.ts + global-error.tsx + @sentry/node onFailure hook in trigger.config.ts — all DSN-gated no-ops until `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` set. Source-map upload (withSentryConfig) skipped deliberately.
+- [x] G2. Covered by the onFailure hook (taskId/runId/payload context) + existing logger calls
+- [x] Bonus: `useCompositeFor` → `shouldCompositeFor` (eslint rules-of-hooks false positive; lint now 0 errors)
+
+## Review
+
+All 7 batches executed and verified. Final gate 2026-07-04: `tsc --noEmit` 0 errors ·
+36/36 vitest · lint 0 errors (4 pre-existing warnings in untouched files) ·
+`next build` clean. DB migration `20260702105109` applied to dev DB (additive).
+
+**User TODOs (things only you can do):**
+1. Test flows, then commit + push (nothing is committed — repo was already fully uncommitted before this session).
+2. `npm i @sentry/node` — currently resolves transitively via @sentry/nextjs; make it direct.
+3. Create Sentry project → set `SENTRY_DSN` + `NEXT_PUBLIC_SENTRY_DSN` in env (Vercel + Trigger.dev).
+4. Deploy trigger tasks (`npx trigger.dev deploy`) — new `creative-edit` task + changed `generation-run` must ship together with the app.
+5. Run a bake-off (super-admin studio form toggle) → crown a model → pin via `IMAGE_PROVIDER`/`GEMINI_IMAGE_MODEL_FAST` env if the winner isn't NB2 flash.
+
+**Known limitations (accepted):**
+- Rate limiter is per-instance (in-memory) — fine pre-launch, swap for Upstash at scale.
+- Placement QA is one retry, fail-open — human Review gate is the backstop.
+- Email-HTML injection surface in send-test-report's inline template noted but untouched (values are zod-validated; full escape pass = backlog).
+- `pipelineChain` in-process serialization of run pipeline JSON — pre-existing, unchanged.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,254 +1,44 @@
-# Round 4 — Productization: dev script, pipeline quality, account types, marketing, AI bot (2026-07-11) — DONE (all R4 items ✅, gate passed 2026-07-11)
+# 2026-07-22b — workspace model picker, multi-pose, aspect fix
+(prev round archived at tasks/todo-r4-archive.md)
 
-Execution order: R4.1 → R4.5 → R4.4 → R4.2 → R4.3
-(pipeline before marketing/bot so copy + bot knowledge describe FINAL capabilities; account types before marketing because login-only changes login copy.)
+## Decisions (from My Lord)
+- Model list: 7 — NB Pro, NB2, GPT Image 2, Seedream v4, Seedream v5 Lite, Qwen-Image (runware:108@1), Wan 2.7 (alibaba:wan@2.7-image). Workspace default, super-admin only.
+- Poses: multi-select REPLACE option count for on-model. M poses → M images, same model+garment. Hide "how many options" for on-model.
+- Aspect: editor "add format" re-renders NATIVE plate (image call) and CHARGES credits.
 
-## R4.1 `npm run dev` runs Trigger.dev too — ✅ DONE
-- [x] `dev` = concurrently(next dev, trigger dev); `dev:next`/`dev:trigger` standalone
-- [x] devDeps: concurrently@^10, trigger.dev@4.4.6 (pinned = SDK version); allowScripts approvals for CLI esbuild/@depot postinstalls
-- [x] Verified 25s smoke run; zero prod impact (Vercel runs `next build`; Trigger deploys via `trigger.dev deploy`)
-- [x] DEVLOG entry
+## Plan
+### F1 — Workspace image-model setting (super-admin only)
+- [ ] schema: Workspace.imageModel String?
+- [ ] runware.ts: add qwen_image, wan_2_7 to IMAGE_MODELS
+- [ ] provider.ts: runwareModel on params/variant; seedream path honors it; WORKSPACE_IMAGE_MODELS registry + resolveWorkspaceVariant(); labels
+- [ ] generation-run: select workspace.imageModel; resolve variant (soft-prefer, keep fallback)
+- [ ] actions/workspace.ts: setWorkspaceImageModel (requireSuperAdmin)
+- [ ] settings page + client: picker visible only to super admin
 
-## R4.5 Pipeline review + quality-first hardening
-- [ ] Fallback chain → tiered steps in src/lib/image/provider.ts:
-      **Nano Banana Pro (gemini hero) → gpt-image-2 → Nano Banana 2 (gemini default) → Seedream** (user-specified order)
-      — single reusable FALLBACK_CHAIN of {provider, tier} consumed by generateScene; call-site API unchanged
-- [ ] Default render tier → hero / NB Pro (quality > cost, per user)
-- [ ] BRIEF VALIDATOR stage: semantic QA of concepts (product/brand/occasion consistency) + one repair round, between CONCEPTING and RENDERING
-- [ ] PROMPT ENHANCER stage in-pipeline for image prompts (enhance-prompt.ts is UI-only today)
-- [ ] Fail-open QA gates (pack-qa, placement-qa): add one extra quality-critical retry
-- [ ] Tests: chain order, validator schema; tsc + vitest green
-- [ ] UI: NB Pro default pref; label fallback-used
-- [ ] DEVLOG entry
+### F2 — Multi-pose (on-model)
+- [ ] schema: GenerationRun.modelPoses String[]
+- [ ] create-form: pose multi-select; hide optionCount for on-model; cost = poses×perConcept
+- [ ] generate.ts: parse modelPoses; on-model conceptCount = poses.length (min 1)
+- [ ] generation-run: on-model per-pose queue (1 concept × M poses); poseOverride → buildOnModelPrompt
 
-## R4.4 3 account types + workspaces + login-only + invites
-- [ ] schema: enum WorkspaceType { FMCG_PRODUCT, APPAREL_ON_MODEL, FASHION_EDITORIAL } + Workspace.type; Creative.deletedAt
-- [ ] Thread type → AuthContext + generation defaults (FMCG: SKU + festival/theme/custom, EXACT_PRODUCT/IN_SCENE; APPAREL: ON_MODEL standard; FASHION: ON_MODEL editorial-campaign prompt flavor)
-- [ ] Login-only: signIn callback denies unknown emails (no User + no PENDING invite) → "invite required" page; remove auto-workspace-create; fix login caption
-- [ ] Invite email: src/lib/email.ts (nodemailer GMAIL_* pattern from send-enquiry) sent from inviteMember
-- [ ] Workspace setup + creative soft-delete script (DESTRUCTIVE — only after explicit user confirm)
-- [ ] Re-run refreshBrandIntel per workspace after setup
-- [ ] Additive prisma migration
-- [ ] DEVLOG entries
+### F3 — Aspect native re-render + charge
+- [ ] paid-edits.ts: applyRenderAspect re-renders native plate via generateScene, not cover-crop
+- [ ] actions/editor.ts: renderNewAspect debits + insufficient handling
+- [ ] creative-edit.ts: render_aspect debited → catchError refunds
+- [ ] editor.tsx: "add format" copy reflects credit cost
 
-## R4.2 Marketing redesign (design-taste-frontend skill)
-- [ ] Read SKILL.md lines 509+ first
-- [ ] Scope: src/app/(marketing)/* + src/components/marketing/* + mk-tokens in globals.css
-- [ ] Remove ALL 44 user-facing em-dashes (rewrite sentences, not mechanical swaps)
-- [ ] Studio copy = real capabilities (overlay compositor, NOT "typography set into the image"; verify 45-occasions count, credits, languages, refund + QA claims)
-- [ ] Skill hard rules: hero discipline, eyebrow cap, section variety, CTA dedup, image strategy
-- [ ] DEVLOG entry
+### Verify
+- [ ] tsc + lint + vitest + migrate + real e2e both kinds
+- [ ] DEVLOG entries; My Lord sets TRIGGER_ACCESS_TOKEN secret
 
-## R4.3 AI bot (Synerix-scoped, Gemini Flash)
-- [ ] Vercel AI SDK (`ai` + `@ai-sdk/google`, already installed): streamText, `gemini-flash-latest`; env GOOGLE_GENERATIVE_AI_API_KEY (user adds)
-- [ ] src/app/api/chat/route.ts guardrails: scoped system prompt + embedded knowledge base, topic refusal, input/output caps, message-count cap, rate limit (src/lib/rate-limit.ts), no tools, no prompt disclosure
-- [ ] Floating chat widget in (marketing) layout
-- [ ] DEVLOG entry
+## Review — DONE (all 3 features built + verified)
+- F1 image-model picker: 7 models (NB Pro/NB2/GPT/Seedream v4/Seedream v5 Lite/Qwen-Image/Wan 2.7), super-admin-only in settings, soft-prefer with cascade kept. 4 new unit tests incl. fallback-model-isolation guard.
+- F2 multi-pose: verified live — 2 poses → 2 creatives, each with its own pose (run 8ac7da08). Option picker hidden for on-model.
+- F3 aspect native re-render: verified live — new 1:1 got a native plate (0-1x1.png) recorded in aspectPlateKeys, not a crop. Now charges credits (regen cost); refund on failure both paths.
+- Verify: tsc ✓, lint ✓, vitest 62 ✓, real e2e both kinds ✓ (in-scene 1.9m, on-model 3.3m).
+- Migrations 20260722115500 (cutout) + 20260722133655 (imageModel+modelPoses) applied to prod DB — nullable/backward-compatible, old prod code unaffected.
 
-## Review (2026-07-11)
-- R4.1 ✅ dev script (verified via 25s smoke run)
-- R4.5 ✅ tiered cascade NB Pro → GPT → NB2 → Seedream (resolveSceneChain, 4 new tests); brief validator + repair (sonnet judge, opus repair, fail-open); batch prompt enhancer (opus, guarded); pack QA 2 retries; placement QA 2 runner-ups; fallback badge on single picks
-- R4.4 ✅ code + DB EXECUTED (user confirmed 2×): migration applied; 39 creatives soft-deleted; FMCG Creative Studio / Apparel Studio / Fashion Editorial Studio created (owner dev@synerix.local, god-view covers all); invite-only auth + /request-access; invite emails; soft-delete filters on 9 reads; FASHION_EDITORIAL brief flavor
-- R4.2 ✅ marketing polish: truthful Studio copy (overlay-first, invite-only), zero em/en dashes, eyebrow rationing 6→2/page, hero discipline, bento features, CTA dedup. Verified: build + lint + tsc clean
-- R4.3 ✅ chat bot: /api/chat (AI SDK v6 + gemini-flash-latest, zod validation, rate limit 10/min, 500-token cap, scope-locked system prompt, 503 w/o key) + mk-styled floating widget in (marketing) layout
-- Gate: tsc 0 · 49/49 vitest · eslint clean · next build clean
-- User TODOs: add GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLIENT_ID/SECRET, GMAIL_USERNAME/PASSWORD, SUPER_ADMIN_EMAIL; sign in once w/ Google before running setup script; `npx trigger.dev deploy` when ready
-
----
-
-# Round 3 — Quality reset after floating-pack run (2026-07-05) — ✅ EXECUTED
-
-User's verdict on run 2: pack floating mid-air (crude cut-out paste), dull scene, still blue CTA.
-Directive: quality over cost; latest opus/sonnet for concepting; NB Pro / GPT-Image-2 for images;
-user-selectable "both" for comparison.
-
-- [x] R3.1 Concepts → claude-opus-4-8 (enhance rides same slot); research → claude-sonnet-5;
-      pricing table updated; live smoke test passed on both
-- [x] R3.2 Cut-out paste RETIRED: EXACT_PRODUCT renders in-scene on premium model + pack-fidelity QA
-      (label verified vs reference, one strict retry); concepts.ts stages pack prominent + label-readable
-      instead of forcing product_hero; cutout.ts left in place but unused (deletion not approved)
-- [x] R3.3 Image model picker in create form (all users): Nano Banana Pro (default) / GPT Image 2 /
-      Both — compare (2× credits, per-option side-by-side with model badges on the run page)
-- [x] R3.4 Single picks soft-prefer (fallback chain kept); compare/bake-off hard-forced;
-      GenerationRun.imageModelPref (+migration); refund math unchanged (queue doubles with cost)
-- [x] R3.5 Editor paid edits → hero tier (same premium bar as generation)
-
-Gate: tsc 0 · 36/36 vitest · lint 0 errors · build clean · live opus/sonnet smoke OK.
-**User TODOs:** re-test the same Gillco brief (pick "Both — compare" to judge NB Pro vs GPT-Image-2);
-`npx trigger.dev deploy`; re-ingest Gillco (or set brand colors in Brand Kit) to kill the blue CTA;
-note per-run API cost now higher (~$0.15-0.30 concepting + $0.134/img NB Pro) — visible in /admin/costs.
-
----
-
-# Round 2 — Quality/Perf/Content fixes (2026-07-04) — ✅ EXECUTED 2026-07-05
-
-User's 7 concerns from first real run (Gillco "Punjabi Poori Atta", 9:16, EXACT_PRODUCT, Friendship Day).
-Root causes investigated (4 subagent audits + DB inspection of run 82e64023). Plan below; verify per batch:
-`npx tsc --noEmit` + `npm test` + `npm run build` + touched flow.
-
-## Batch 1 — Output quality: overlay typography (user items 2)
-- [x] 1a. Local-contrast enforcement: sample plate pixels under each text layer + CTA pill in
-      composeAllAspects; WCAG ratio < threshold → remap colorRole to ink/white or luminance-shifted
-      variant (new helper in src/lib/composition/analyze.ts)
-- [x] 1b. Un-dead the `dominant` param in resolveRoles (src/lib/composition/color.ts:24): accent too
-      close in hue/luminance to a dominant plate color → substitute
-- [x] 1c. Empty-band anchoring: analyzeRegions 3 fixed thirds → 6–8 bands returning calmest band's
-      y-range; anchor copy block into it; on 9:16 drop safeBottom 400 → ~120 when bottom band calm
-- [x] 1d. Fix 9:16 band classifier (score.ts:72-74): classify by headline center vs thirds
-- [x] 1e. Placement QA hardening: per-layer verdict schema (eyebrow/headline/body/cta/logo ×
-      overlaps/lowContrast); retry must differ in archetype; double-fail → render guaranteed-legible
-      fallback (clean-bottom, all-ink, scrim 0.75) instead of shipping the failure
-- [x] 1f. Wire concept typographySpec zone (generated + reserved in plate, currently discarded) into
-      selectTemplates signals
-
-## Batch 2 — Output quality: exact-pack fidelity + brand palette (user items 3 + root of 2's blue)
-- [x] 2a. Thread fidelityMode into generateConcepts; EXACT_PRODUCT → force/strongly-prefer
-      productPlacement=product_hero (composite path = real pack pixels)
-- [x] 2b. Pack-region vision QA for residual in-scene renders in EXACT_PRODUCT: compare rendered pack
-      vs reference photo; mismatch → re-render once or demote to composite fallback
-- [x] 2c. Brand ingest palette hygiene: prompt prefers logo/brand-mark colors, rejects generic UI
-      blues; validate against extracted logo palette before persisting primaryColorHex/accentColorsHex
-- [x] 2d. (decide) hero tier (NB Pro) for in-scene EXACT_PRODUCT renders — 2.2× image cost on those
-
-## Batch 3 — Performance (user item 4)
-- [x] 3a. db.ts:23 pool max 1 → 5 (unblocks all Promise.all query fan-outs)
-- [x] 3b. ensureMembership early-return when no invites + memberships exist (−2 queries/request)
-- [x] 3c. Cache signed URLs: unstable_cache around getSignedThumbUrls/getSignedUrls, revalidate 3300s
-- [x] 3d. Remove double render: drop router.refresh() from editor mutate() success (actions already
-      revalidatePath)
-- [x] 3e. Studio polling: refresh only on realtime done-increment/terminal; interval = fallback only
-- [x] 3f. renderNewAspect (size generation) → existing Trigger.dev pending-edit path
-- [x] 3g. Drop layout's duplicate memberships query (expose from requireAuth)
-
-## Batch 4 — Per-run cost dashboard (user item 1)
-- [x] 4a. Runs list page: every generation run + credits debited + USD total (ApiCostLog has
-      runId+stage already — pure UI). DECIDE: super-admin only (raw USD = internal margin data) vs
-      workspace-visible
-- [x] 4b. Run drilldown: per-stage cost table (concepts/enhance/image/placement-qa/…), per-source
-      totals incl. editor/dissect/brand-research
-
-## Batch 5 — Festival picker in create form (user item 5)
-- [x] 5a. Occasion selector inside studio create form (upcoming calendar entries + custom brief),
-      not only via home/calendar deep-link ?occasion=
-
-## Batch 6 — Marketing site content + responsive (user item 6)
-- [x] 6a. Home: consulting-led hero; restore old 6-service catalogue (data/features.ts base,
-      enriched in new concrete voice); restore Why-Us pillars + real testimonial (verify facts);
-      stats row → verifiable facts; de-festival the Studio band
-- [x] 6b. /consulting: expand 4 → 6 service areas; add Who-we-are (25+ yrs credential — verify);
-      keep engagement cadence + free-first-conversation
-- [x] 6c. /synerix-studio: kill over-claims ("agency-grade", "pixel-faithful", "never drawn wrong",
-      "swear an agency made", "45+"→"45"); lead with your-product-your-brand; festivals = one bullet;
-      foreground true differentiators (refunds, 4 concepts, 4 languages, human activation)
-- [x] 6d. Responsive nits: admin leads grid-cols-3 → responsive; admin tabs overflow-x-auto;
-      create-form/editor unprefixed grids checked at 320px
-- [x] 6e. Unify WhatsApp number to env WHATSAPP_NUMBER (3 hardcoded sites); metadata de-hype
-- [x] 6f. Verify CREDIT_COSTS.perConcept + LIMITS.maxConceptsPerRun match pricing copy
-
-## Batch 7 — Onboarding workspace profile (user item 7)
-- [x] 7a. Add 2–3 skippable onboarding questions: industry/category, primary use case, sells via
-      (marketplace/D2C/offline); store on Workspace
-- [x] 7b. Profile drives surface: hide/deprioritize Models nav + on-model mode where irrelevant
-      (e.g. packaged-foods brand), default fidelity mode, calendar relevance ordering
-
-## Round 2 Review (2026-07-05)
-
-Final gate: `tsc --noEmit` 0 · 36/36 vitest · lint 0 errors (4 pre-existing warnings) ·
-`next build` clean. New migration `20260704202919_add_workspace_profile` applied to dev DB (additive).
-DEVLOG entries per batch. Decisions as approved: cost dashboard super-admin only; exact-pack forces
-product_hero + pack QA; hero tier NOT enabled (revisit post bake-off).
-
-**Deviations / notes:**
-- 2b "demote to composite fallback" → implemented as one strict re-render + verdict in critic
-  (crude center-paste composite onto an already-staged scene looks sticker-like; review gate + verdict
-  is the better failure mode).
-- 1c safeBottom drops to 160 (not 120) when the 9:16 bottom band is calm — keeps motto/contact clear.
-- 6a testimonial: the "Utkarsh Singh @AccioJob" quote in the old repo was a commented-out TEMPLATE
-  placeholder (praising "Monkster"), never a real client quote → REMOVED from both pages; a marked
-  slot comment remains. Add only real verified quotes.
-- 4: an older uncommitted aggregate-only /admin/costs page existed; replaced by the run-centric
-  dashboard (spec matched your ask). Old aggregate view not preserved.
-- 7b calendar-relevance ordering + default-fidelity by profile deferred (profile data must exist first);
-  on-model is hidden by product category (APPAREL) in the create form — stronger signal than profile.
-- Incident: a subagent's `git stash` transiently reverted uncommitted `prisma/schema.prisma` to HEAD;
-  fully restored from the generated client's embedded inlineSchema + verified (`prisma validate`, 24 models).
-
-**User TODOs:**
-1. Test flows, then commit + push yourself (nothing committed). Suggested first test: repeat the
-   Gillco Friendship-Day 9:16 EXACT_PRODUCT run and compare against the old output.
-2. Deploy trigger tasks (`npx trigger.dev deploy`) — generation-run, brand-ingest, creative-edit all changed.
-3. Re-ingest the Gillco brand (or manually set brand colors) so the logo-grounded palette replaces the blue.
-4. Verify consulting-page claims you alone can confirm: "25+ years", "run, grown and rescued real businesses".
-5. Set `WHATSAPP_NUMBER` env (falls back to +91 92164 92174).
-6. Sentry TODOs from round 1 still open (`npm i @sentry/node`, set DSNs).
-
----
-
-# Productionize — Synerix Studio (2026-07-02)
-
-Decisions locked via grill session. I edit only — user tests, commits, pushes.
-Verify after every batch: `npx tsc --noEmit` + `npm test` + `npm run build` + touched flow.
-
-## Batch A — Security (highest risk, safe fixes) ✅ verified (tsc clean, 36/36 tests)
-- [x] A1. Delete `src/app/api/_debug-db/route.ts` (public DB-info leak; no caller in src)
-- [x] A2. `GET /api/health` — public but leak-free (ok/503 only) + rate-limited; deviation from "auth-gated": uptime monitors can't hold sessions, nothing sensitive returned
-- [x] A3. `src/lib/rate-limit.ts` — in-memory sliding-window limiter (per-instance on serverless; fine at current traffic)
-- [x] A4. `/api/check-user` → boolean-only (`hasTakenTest` + copy, no score/date), rate-limited 20/10min; wizard's orphaned score/date display + type fields removed; same oracle neutered in send-test-report 409 branch
-- [x] A5. Rate-limited `/api/send-enquiry` (5/h/IP) + `/api/send-test-report` (3/h/IP)
-- [x] A6. No change — 50mb already right-sized: comment in next.config.ts covers the legit 5×8MB product-form max with margin
-
-## Batch B — Cleanup + docs ✅ verified (tsc clean, 36/36 tests)
-- [x] B1. Deleted `legacy/`, `graphify-out/` (+ gitignore), spikes except `FINDINGS.md`, 5 `scripts/_*.mjs` debug scripts
-- [x] B2. Removed `satori` + `@resvg/resvg-js` deps (only non-spike match was a comment)
-- [x] B3. Removed `flux_2_pro`; `deriveProductPlacement` stub replaced by wiring real `concept.productPlacement` → `selectTemplates` (root-cause fix); `IMAGE_MODEL_SLOTS` restructure deferred to C1; `seedream_v5_lite` kept (not approved for removal)
-- [x] B4. Sharing copy fixed in editor + preview-stage
-- [x] B5. `CONTEXT.md` trued: overlay-first typography, env-driven model tier, bake-off note
-- [x] B6. `DEVLOG.md` created (committed mode — default chosen while user AFK, reversible) + discipline snippet in project CLAUDE.md
-
-## Batch C — Model config unification + admin bake-off ✅ verified (tsc clean, 36/36 tests, migration applied)
-- [x] C1. Editor paid edits migrated to `generateScene` router (env-driven default = NB2 flash via existing `GEMINI_IMAGE_MODEL_FAST`/`IMAGE_PROVIDER`, fallback chain, + editor costs now land in ApiCostLog via new "editor" source); `IMAGE_MODEL_SLOTS` deleted
-- [x] C2. Bake-off: `GenerationRun.bakeoff` + `Creative.imageModel` columns (migration `20260702105109`); super-admin toggle in create form; fan-out concepts × {nb2, nb-pro, gpt-image-2, seedream} with forced provider (no fallback); zero debit + refund guard; model labels on run rail
-- [x] C3. Normal runs untouched: single variant, fallback chain intact
-
-## Batch D — Overlay placement QA ✅ verified (tsc clean, 36/36 tests)
-- [x] D1. `placement-qa.ts` vision check on composited pixels; fail → re-composite with runner-up template, re-check once, fail-open; verdict stored in `critic.placementQa`; cost-tracked
-- [x] (F3 pulled forward) `conceptStatus` wired: failed work items render as distinct slots with error tooltip; PARTIAL runs now explain themselves
-
-## Batch E — Editor async migration ✅ verified (tsc clean, 36/36 tests)
-- [x] E1. `src/lib/editor/paid-edits.ts` + `creative-edit` task; debit stays sync in actions, refunds live next to failures, no double-refund paths
-- [x] E2. Editor watches the task via useRealtimeRun (scoped 15-min token, 60s-refresh fallback); per-lane busy states preserved via derived consts
-
-## Batch F — UX polish bundle ✅ (agent-implemented, verified: tsc 0, 36/36, lint 0 new)
-- [x] F1. Library pagination (?page/?rpage + counts + Prev/Next, tab preserved)
-- [x] F2. `AutoRefresh` component on Products + Models lists (4s while non-terminal)
-- [x] F3. Done in Batch C/D pass (failed-slot display on run canvas)
-- [x] F4. ProductActions toasts on delete/re-analyze results
-- [x] F5. Brand-kit client form wrapper: pending + toasts (orphaned void wrapper removed)
-- [x] F6. Onboarding ingest: always-visible "fill in manually" escape (chose simpler variant over 60s timer)
-- [x] F7. Dashboard checklist: real done states + destructive failed-ingest hint
-- [x] F8. `addProductImages` action (reuses createProduct validation, 5-cap, no re-dissect — dissection reads primary image only) + add-photos tile on detail page
-- [x] F9. Model delete → Dialog confirm
-
-## Batch G — Ops ✅ verified (full gate: tsc 0, 36/36 tests, lint 0 errors, build clean)
-- [x] G1. Sentry: instrumentation.ts + instrumentation-client.ts + global-error.tsx + @sentry/node onFailure hook in trigger.config.ts — all DSN-gated no-ops until `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` set. Source-map upload (withSentryConfig) skipped deliberately.
-- [x] G2. Covered by the onFailure hook (taskId/runId/payload context) + existing logger calls
-- [x] Bonus: `useCompositeFor` → `shouldCompositeFor` (eslint rules-of-hooks false positive; lint now 0 errors)
-
-## Review
-
-All 7 batches executed and verified. Final gate 2026-07-04: `tsc --noEmit` 0 errors ·
-36/36 vitest · lint 0 errors (4 pre-existing warnings in untouched files) ·
-`next build` clean. DB migration `20260702105109` applied to dev DB (additive).
-
-**User TODOs (things only you can do):**
-1. Test flows, then commit + push (nothing is committed — repo was already fully uncommitted before this session).
-2. `npm i @sentry/node` — currently resolves transitively via @sentry/nextjs; make it direct.
-3. Create Sentry project → set `SENTRY_DSN` + `NEXT_PUBLIC_SENTRY_DSN` in env (Vercel + Trigger.dev).
-4. Deploy trigger tasks (`npx trigger.dev deploy`) — new `creative-edit` task + changed `generation-run` must ship together with the app.
-5. Run a bake-off (super-admin studio form toggle) → crown a model → pin via `IMAGE_PROVIDER`/`GEMINI_IMAGE_MODEL_FAST` env if the winner isn't NB2 flash.
-
-**Known limitations (accepted):**
-- Rate limiter is per-instance (in-memory) — fine pre-launch, swap for Upstash at scale.
-- Placement QA is one retry, fail-open — human Review gate is the backstop.
-- Email-HTML injection surface in send-test-report's inline template noted but untouched (values are zod-validated; full escape pass = backlog).
-- `pipelineChain` in-process serialization of run pipeline JSON — pre-existing, unchanged.
+## State / open
+- ALL of this session's work is UNCOMMITTED (last commit 72b6ed1). Batch A (timeout/cutouts/e2e/CI) was deployed to prod last part but not committed; Batch B (these 3 features) is neither committed nor deployed.
+- Awaiting My Lord: test → then commit (retroactive-commit-history) + deploy (Trigger prod + Vercel prod).
+- Still pending: My Lord sets TRIGGER_ACCESS_TOKEN gh secret (dashboard PAT) — blocks CI trigger-deploy + e2e worker.


### PR DESCRIPTION
Three owner-requested features plus the earlier reliability batch.

## Features
- **Super-admin workspace image-model picker** — Settings → "Image model (admin)". 7 models (NB Pro, NB2, GPT Image 2, Seedream v4, Seedream v5 Lite, Qwen-Image, Wan 2.7). Chosen model leads each run; resilience cascade kept behind it.
- **Multi-pose on-model** — poses are multi-select and drive the on-model output count: N poses → N images of the same model + garment. Verified live (2 poses → 2 creatives).
- **Native aspect re-render** — editor "add format" now generates a native plate per ratio (no crop) and charges credits. Verified live (native 1:1 plate created).

## Also in this batch
- Generate-action cold-start timeout fix (maxDuration=60).
- One-time product background-removal cutouts, reused as generation references.
- Real-generation e2e harness (cheap models) + E2E workspace seed + CI/e2e GitHub Actions.

## Verification
tsc ✓ · lint ✓ · vitest 62 ✓ (4 new) · real e2e both kinds ✓ · multi-pose + aspect re-render spot-checked live.

Migrations 20260722115500 (cutout) + 20260722133655 (imageModel + modelPoses) are nullable/backward-compatible.