### PR TITLE
Workspace account types drive photography style (FMCG / e-com apparel / premium fashion)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -67,6 +67,29 @@ New entries go at the **top** of the Log section (reverse chronological).
 
 ## Log
 
+### 2026-07-23 — Workspace account types drive photography style (FMCG / e-com apparel / premium fashion)
+
+- Type: feature
+- Scope: src/lib/workspace-type.ts (new), src/components/account-type-picker.tsx (new), src/app/(admin)/admin/new-workspace-dialog.tsx, src/app/(app)/onboarding/wizard.tsx, src/app/actions/brand.ts, src/lib/workspace-profile{,-server}.ts, src/app/(app)/settings/{page,settings-client}.tsx, src/app/actions/workspace.ts, src/lib/pipeline/image-prompt.ts, src/trigger/generation-run.ts, tests
+
+Reasoning / RCA / research:
+    - Three customer segments (Gillco-style FMCG campaigns, normal e-com apparel, premium fashion) needed distinct generation styles, selectable at workspace level incl. onboarding. Key finding: the `WorkspaceType` enum already existed with exactly these 3 values but only `FASHION_EDITORIAL` branched anywhere, and onboarding used a parallel legacy classification (`industry`/`primaryUseCase`) that never set it — two disconnected systems. Chose to make `WorkspaceType` the single source of truth rather than add a fourth field; zero migrations needed.
+    - Photography language reverse-engineered from live references: schein.in (e-com apparel = soft diffused daylight, warm beige/cream minimal architectural sets, muted pastels, garment-hero full figure + crisp fabric macro detail) and theblueman.net (premium fashion = character-driven campaign: styled model w/ accessories, environmental sets with depth/props, directional/rim light, rich confident grade). Screenshotted both sites' product photos and wrote `ON_MODEL_DIRECTION` + ACCOUNT STYLE blocks against what's actually in frame, not generic "editorial" adjectives.
+    - Deliberately did NOT ban campaign concepts for APPAREL_ON_MODEL accounts — an e-com apparel brand still runs festival campaigns; its ACCOUNT STYLE block steers them tasteful/minimal instead of forbidding them. FMCG adds no block (base behavior IS its style).
+    - Mode selection in the studio stays product-category driven (unchanged) — workspace type sets style, product category sets mechanics; an FMCG workspace with an apparel product still gets on-model.
+    - `showsModelSurface` keys on type first, but FMCG_PRODUCT is also the schema default so it can't distinguish a real choice from a never-classified legacy workspace — kept the legacy-profile fallback (incomplete data → show everything) instead of hiding the Models tab on old workspaces.
+    - Decisions from My Lord: type is owner/admin editable in settings (not super-admin-only like the image model); onboarding's Industry + Mainly-creating selects are replaced by the required 3-card picker (salesChannel kept, legacy columns no longer written).
+
+Implementation summary:
+    - Shared `WORKSPACE_TYPES` metadata + `AccountTypePicker` radio-card component extracted from the admin dialog; reused in admin, onboarding, settings.
+    - `saveWorkspaceProfile` persists `workspace.type`; new `setWorkspaceType` action reuses `requireManager`; settings shows the picker read-only for non-managers.
+    - Rewrote both `ON_MODEL_DIRECTION` strings (schein/blueman anchored) and extended the brief-level ACCOUNT STYLE injection to a 3-way switch in generation-run.ts.
+    - Verified: tsc/lint clean, 65 vitest pass (new showsModelSurface matrix + updated direction assertions); live smoke on dev server — settings picker persists + reverts, onboarding renders picker and required-radio blocks submit without a choice.
+
+Follow-ups deferred:
+    - Prod data flags (My Lord to fix via the new settings card): "Synerix Apparel" and "E2E Tests" workspaces are typed FMCG_PRODUCT but are apparel accounts.
+    - Pre-existing cosmetic bug spotted: the super-admin image-model Select renders raw `__default__` in its trigger instead of the "Default (quality-first cascade)" label.
+
 ### 2026-07-22 — Super-admin workspace image-model picker (7 models incl. cheap Chinese Runware models)
 
 - Type: feature

--- a/src/app/(admin)/admin/new-workspace-dialog.tsx
+++ b/src/app/(admin)/admin/new-workspace-dialog.tsx
@@ -16,18 +16,14 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-
-const WORKSPACE_TYPES = [
-  { id: "FMCG_PRODUCT", label: "FMCG / Product SKU", hint: "Product packs + festivals, themes and custom briefs" },
-  { id: "APPAREL_ON_MODEL", label: "Apparel on AI models", hint: "Everyday clothing worn by AI models" },
-  { id: "FASHION_EDITORIAL", label: "Fashion editorial", hint: "High-end apparel, designer-campaign photoshoot look" },
-] as const;
+import { AccountTypePicker } from "@/components/account-type-picker";
+import type { WorkspaceTypeId } from "@/lib/workspace-type";
 
 /** Admin-provisioned workspace creation (invite-only onboarding). */
 export function NewWorkspaceDialog() {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
-  const [type, setType] = useState<string>("FMCG_PRODUCT");
+  const [type, setType] = useState<WorkspaceTypeId>("FMCG_PRODUCT");
   const [url, setUrl] = useState("");
   const [pending, startTransition] = useTransition();
 
@@ -69,29 +65,7 @@ export function NewWorkspaceDialog() {
           </div>
           <div className="space-y-1.5">
             <Label>Account type</Label>
-            <div className="space-y-1.5">
-              {WORKSPACE_TYPES.map((t) => (
-                <label
-                  key={t.id}
-                  className={`flex cursor-pointer items-start gap-2 rounded-md border p-2.5 text-sm transition-colors ${
-                    type === t.id ? "border-primary bg-primary/5" : "border-border hover:bg-muted/50"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="ws-type"
-                    value={t.id}
-                    checked={type === t.id}
-                    onChange={() => setType(t.id)}
-                    className="mt-0.5"
-                  />
-                  <span>
-                    <span className="font-medium">{t.label}</span>
-                    <span className="block text-xs text-muted-foreground">{t.hint}</span>
-                  </span>
-                </label>
-              ))}
-            </div>
+            <AccountTypePicker name="ws-type" value={type} onChange={setType} />
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="ws-url">Client website (optional)</Label>

--- a/src/app/(app)/onboarding/wizard.tsx
+++ b/src/app/(app)/onboarding/wizard.tsx
@@ -10,59 +10,42 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { PROFILE_CHANNELS, PROFILE_INDUSTRIES, PROFILE_USE_CASES } from "@/lib/workspace-profile";
+import { PROFILE_CHANNELS } from "@/lib/workspace-profile";
+import { AccountTypePicker } from "@/components/account-type-picker";
+import type { WorkspaceTypeId } from "@/lib/workspace-type";
 
 type Mode = "url" | "manual";
 type Status = "NONE" | "PENDING" | "CRAWLING" | "EXTRACTING" | "READY" | "FAILED";
 
-/** Optional business-profile answers, shared by both forms. They tailor which
- * surfaces the workspace sees (e.g. AI models only for apparel businesses). */
-function ProfileFields() {
+/** Business-profile answers, shared by both forms. The account type is the
+ * one that matters — it sets the workspace's photography + concept style and
+ * which surfaces it sees (e.g. AI models only for apparel businesses). */
+function ProfileFields(props: {
+  accountType: WorkspaceTypeId | "";
+  onAccountType: (id: WorkspaceTypeId) => void;
+}) {
   return (
     <div className="space-y-4 rounded-xl border border-border bg-muted/30 p-4">
-      <p className="text-xs font-medium text-muted-foreground">
-        A little about the business <span className="font-normal">(optional — helps us show the right tools)</span>
-      </p>
-      <div className="grid gap-4 sm:grid-cols-3">
-        <div className="space-y-2">
-          <Label htmlFor="profile-industry">Industry</Label>
-          <Select name="industry">
-            <SelectTrigger id="profile-industry" className="w-full">
-              <SelectValue placeholder="Choose…" />
-            </SelectTrigger>
-            <SelectContent>
-              {PROFILE_INDUSTRIES.map((o) => (
-                <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="profile-usecase">Mainly creating</Label>
-          <Select name="primaryUseCase">
-            <SelectTrigger id="profile-usecase" className="w-full">
-              <SelectValue placeholder="Choose…" />
-            </SelectTrigger>
-            <SelectContent>
-              {PROFILE_USE_CASES.map((o) => (
-                <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="profile-channel">You sell via</Label>
-          <Select name="salesChannel">
-            <SelectTrigger id="profile-channel" className="w-full">
-              <SelectValue placeholder="Choose…" />
-            </SelectTrigger>
-            <SelectContent>
-              {PROFILE_CHANNELS.map((o) => (
-                <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+      <div className="space-y-2">
+        <p className="text-xs font-medium text-muted-foreground">
+          What kind of business is this? <span className="font-normal">— this sets your photography style</span>
+        </p>
+        <AccountTypePicker value={props.accountType} onChange={props.onAccountType} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="profile-channel">
+          You sell via <span className="font-normal text-muted-foreground">(optional)</span>
+        </Label>
+        <Select name="salesChannel">
+          <SelectTrigger id="profile-channel" className="w-full">
+            <SelectValue placeholder="Choose…" />
+          </SelectTrigger>
+          <SelectContent>
+            {PROFILE_CHANNELS.map((o) => (
+              <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
     </div>
   );
@@ -81,6 +64,7 @@ export function OnboardingWizard(props: {
 }) {
   const router = useRouter();
   const [mode, setMode] = useState<Mode>("url");
+  const [accountType, setAccountType] = useState<WorkspaceTypeId | "">("");
   const [status, setStatus] = useState<Status>(props.initialStatus);
   const [error, setError] = useState<string | null>(props.initialError);
   const [pending, startTransition] = useTransition();
@@ -192,7 +176,7 @@ export function OnboardingWizard(props: {
                     required
                   />
                 </div>
-                <ProfileFields />
+                <ProfileFields accountType={accountType} onAccountType={setAccountType} />
                 <Button type="submit" disabled={pending} className="w-full" size="lg">
                   {pending ? "Starting…" : "Analyze my website"}
                 </Button>
@@ -241,7 +225,7 @@ export function OnboardingWizard(props: {
                     placeholder="Fresh mithai in pure desi ghee since 1987"
                   />
                 </div>
-                <ProfileFields />
+                <ProfileFields accountType={accountType} onAccountType={setAccountType} />
                 <Button type="submit" disabled={pending} className="w-full" size="lg">
                   {pending ? "Saving…" : "Save & continue"}
                 </Button>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -40,6 +40,7 @@ export default async function SettingsPage() {
           <CardContent>
             <SettingsClient
               workspaceName={workspace.name}
+              workspaceType={workspace.type}
               canManage={canManage}
               isSuperAdmin={ctx.isSuperAdmin}
               imageModel={workspace.imageModel}

--- a/src/app/(app)/settings/settings-client.tsx
+++ b/src/app/(app)/settings/settings-client.tsx
@@ -10,8 +10,11 @@ import {
   resendInvite,
   revokeInvite,
   setWorkspaceImageModel,
+  setWorkspaceType,
   updateMemberRole,
 } from "@/app/actions/workspace";
+import { AccountTypePicker } from "@/components/account-type-picker";
+import type { WorkspaceTypeId } from "@/lib/workspace-type";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -66,6 +69,7 @@ const DEFAULT_MODEL = "__default__"; // Select needs a non-empty value for "use 
 
 export function SettingsClient(props: {
   workspaceName: string;
+  workspaceType: string;
   canManage: boolean;
   isSuperAdmin: boolean;
   imageModel: string | null;
@@ -76,6 +80,7 @@ export function SettingsClient(props: {
 }) {
   const [pending, startTransition] = useTransition();
   const [wsName, setWsName] = useState(props.workspaceName);
+  const [wsType, setWsType] = useState(props.workspaceType as WorkspaceTypeId);
   const [imageModel, setImageModel] = useState(props.imageModel ?? DEFAULT_MODEL);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState("EDITOR");
@@ -117,6 +122,34 @@ export function SettingsClient(props: {
           <Separator />
         </>
       )}
+
+      {/* Account type — sets the photography + concept style of future
+          generations. Editable by owner/admin; read-only for everyone else. */}
+      <div className="space-y-1.5">
+        <Label>Account type</Label>
+        <AccountTypePicker
+          value={wsType}
+          disabled={!props.canManage || pending}
+          onChange={(id) => {
+            if (id === wsType) return;
+            const prev = wsType;
+            setWsType(id);
+            startTransition(async () => {
+              try {
+                await setWorkspaceType(id);
+                toast.success("Account type updated");
+              } catch (e) {
+                setWsType(prev);
+                toast.error(errorMessage(e));
+              }
+            });
+          }}
+        />
+        <p className="text-xs text-muted-foreground">
+          Sets the photography &amp; concept style of future generations. Existing creatives are unaffected.
+        </p>
+      </div>
+      <Separator />
 
       {/* Image model — platform super-admin only. Sets the model every run in
           this workspace prefers (fallback cascade kept behind it). */}

--- a/src/app/actions/brand.ts
+++ b/src/app/actions/brand.ts
@@ -9,24 +9,26 @@ import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
 import { ensureBrand } from "@/lib/ensure-brand";
 import { storageKeys, uploadBuffer } from "@/lib/storage";
-import { PROFILE_CHANNELS, PROFILE_INDUSTRIES, PROFILE_USE_CASES } from "@/lib/workspace-profile";
+import { PROFILE_CHANNELS } from "@/lib/workspace-profile";
+import { isWorkspaceTypeId } from "@/lib/workspace-type";
 import type { brandIngest } from "@/trigger/brand-ingest";
 
 const urlSchema = z.string().trim().transform((v) => (/^https?:\/\//i.test(v) ? v : `https://${v}`)).pipe(z.string().url());
 
-/** Persist the optional onboarding profile answers onto the workspace. */
+/** Persist the onboarding profile onto the workspace. The account type is the
+ * canonical classification (drives photography + concept style); the legacy
+ * industry/primaryUseCase columns are no longer written. */
 async function saveWorkspaceProfile(workspaceId: string, formData: FormData): Promise<void> {
-  const pick = (name: string, allowed: readonly { id: string }[]) => {
-    const v = formData.get(name);
-    return typeof v === "string" && allowed.some((a) => a.id === v) ? v : null;
-  };
-  const data = {
-    industry: pick("industry", [...PROFILE_INDUSTRIES]),
-    primaryUseCase: pick("primaryUseCase", [...PROFILE_USE_CASES]),
-    salesChannel: pick("salesChannel", [...PROFILE_CHANNELS]),
-  };
-  if (data.industry || data.primaryUseCase || data.salesChannel) {
-    await prisma.workspace.update({ where: { id: workspaceId }, data });
+  const rawType = formData.get("accountType");
+  const type = isWorkspaceTypeId(rawType) ? rawType : null;
+  const rawChannel = formData.get("salesChannel");
+  const salesChannel =
+    typeof rawChannel === "string" && PROFILE_CHANNELS.some((c) => c.id === rawChannel) ? rawChannel : null;
+  if (type || salesChannel) {
+    await prisma.workspace.update({
+      where: { id: workspaceId },
+      data: { ...(type ? { type } : {}), ...(salesChannel ? { salesChannel } : {}) },
+    });
   }
 }
 

--- a/src/app/actions/workspace.ts
+++ b/src/app/actions/workspace.ts
@@ -5,6 +5,7 @@ import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { sendInviteEmail } from "@/lib/email";
 import { WORKSPACE_IMAGE_MODELS } from "@/lib/image/provider";
+import { isWorkspaceTypeId } from "@/lib/workspace-type";
 import { MembershipRole } from "@/generated/prisma/client";
 
 const MANAGER_ROLES = new Set(["OWNER", "ADMIN"]);
@@ -36,6 +37,15 @@ export async function renameWorkspace(name: string) {
   const trimmed = name.trim();
   if (trimmed.length < 2 || trimmed.length > 60) throw new Error("Name must be 2–60 characters");
   await prisma.workspace.update({ where: { id: ctx.workspaceId }, data: { name: trimmed } });
+  revalidatePath("/settings");
+}
+
+/** Owner/admin: set the workspace account type (photography + concept style
+ * of future generations). */
+export async function setWorkspaceType(type: string) {
+  const ctx = await requireManager();
+  if (!isWorkspaceTypeId(type)) throw new Error("Unknown account type");
+  await prisma.workspace.update({ where: { id: ctx.workspaceId }, data: { type } });
   revalidatePath("/settings");
 }
 

--- a/src/components/account-type-picker.tsx
+++ b/src/components/account-type-picker.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { WORKSPACE_TYPES, type WorkspaceTypeId } from "@/lib/workspace-type";
+
+/**
+ * Radio-card picker for the workspace account type. Controlled; pass `name`
+ * so the checked radio also lands in plain FormData submits (onboarding).
+ */
+export function AccountTypePicker(props: {
+  value: WorkspaceTypeId | "";
+  onChange: (id: WorkspaceTypeId) => void;
+  name?: string;
+  required?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="space-y-1.5">
+      {WORKSPACE_TYPES.map((t) => (
+        <label
+          key={t.id}
+          className={`flex items-start gap-2 rounded-md border p-2.5 text-sm transition-colors ${
+            props.disabled ? "cursor-default opacity-70" : "cursor-pointer"
+          } ${props.value === t.id ? "border-primary bg-primary/5" : "border-border" + (props.disabled ? "" : " hover:bg-muted/50")}`}
+        >
+          <input
+            type="radio"
+            name={props.name ?? "accountType"}
+            value={t.id}
+            checked={props.value === t.id}
+            onChange={() => props.onChange(t.id)}
+            required={props.required}
+            disabled={props.disabled}
+            className="mt-0.5"
+          />
+          <span>
+            <span className="font-medium">{t.label}</span>
+            <span className="block text-xs text-muted-foreground">{t.hint}</span>
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/pipeline/image-prompt.test.ts
+++ b/src/lib/pipeline/image-prompt.test.ts
@@ -87,15 +87,17 @@ describe("buildOnModelPrompt", () => {
 
   it("defaults to the clean-catalog photoshoot direction", () => {
     const p = buildOnModelPrompt({ concept, aspect: "4:5" });
-    expect(p).toMatch(/clean showcase/i);
+    expect(p).toMatch(/premium e-commerce showcase/i);
     expect(p).toMatch(/GARMENT is the hero/i);
+    expect(p).toMatch(/soft, diffused/i); // schein-style light
   });
 
   it("switches to editorial campaign direction when asked", () => {
     const p = buildOnModelPrompt({ concept, aspect: "4:5", direction: "editorial" });
-    expect(p).toMatch(/high-fashion campaign/i);
+    expect(p).toMatch(/premium fashion campaign/i);
     expect(p).toMatch(/85mm/);
-    expect(p).not.toMatch(/clean showcase/i);
+    expect(p).toMatch(/designer lookbook campaign/i); // blueman-style character energy
+    expect(p).not.toMatch(/premium e-commerce showcase/i);
   });
 
   it("appends the direction and quality floors even when the concept carries a full imagePrompt", () => {

--- a/src/lib/pipeline/image-prompt.ts
+++ b/src/lib/pipeline/image-prompt.ts
@@ -53,12 +53,14 @@ const PLAIN_ECOMMERCE =
 export type OnModelDirection = "editorial" | "catalog";
 
 const ON_MODEL_DIRECTION: Record<OnModelDirection, string> = {
-  // High-end fashion accounts: designer-campaign / magazine-editorial energy.
+  // Premium fashion accounts: styled fashion-campaign photograph with
+  // character energy (reference: theblueman.net lookbooks).
   editorial:
-    "PHOTOSHOOT DIRECTION (editorial): shoot it as a high-fashion campaign photograph — 85mm–105mm portrait compression, deliberate directional editorial lighting with sculpted shadows, a styled set or location with real depth and atmosphere, shallow depth of field. The model is impeccably groomed with styled hair and confident, expressive editorial posture and natural hands; styling and any accessories are tasteful and complementary. Restrained, sophisticated colour story. The result must read as a frame from a Vogue-grade designer campaign — never a flat catalogue listing, never mass-market retail energy.",
-  // Regular apparel shops: clean, garment-forward premium showcase.
+    "PHOTOSHOOT DIRECTION (premium fashion campaign): shoot it as a frame from a designer lookbook campaign — 85mm–105mm portrait compression, shallow depth of field, directional natural or rim light with sculpted contrast and real dimensionality. The set is an environment with genuine depth and tasteful props or textures (architectural detail, foliage, weathered wood, an evocative location) — never a bare seamless wall. The model has styled character energy: impeccable grooming, confident expressive posture, natural hands, and tasteful complementary accessories where they suit the garment (sunglasses, a watch, layered pieces). Rich, confident yet controlled colour grade with a sophisticated story. Never a flat catalogue listing, never mass-market retail energy.",
+  // E-commerce apparel accounts: clean premium catalog showcase (reference:
+  // schein.in product photography).
   catalog:
-    "PHOTOSHOOT DIRECTION (clean showcase): shoot it as a premium apparel lookbook photograph — the GARMENT is the hero. Soft, even, flattering key light with gentle falloff; a clean, uncluttered backdrop (seamless studio tone or a calm minimal setting with subtle depth) that never competes with the clothing; crisp focus on the garment's fabric, colour and cut. The model is well-groomed with a natural, confident, relaxed pose that presents the garment clearly — drape, fit and details all readable. Polished e-commerce-editorial quality: clean, premium, true to the garment.",
+    "PHOTOSHOOT DIRECTION (premium e-commerce showcase): shoot it as a premium apparel product photograph — the GARMENT is the hero. Soft, diffused, flattering daylight-quality key light with gentle falloff and delicate soft shadows; a warm neutral minimal set — seamless studio tone or a calm beige/cream architectural backdrop (plaster wall, subtle arch or steps) with quiet depth — that never competes with the clothing. Muted, harmonious palette that flatters the garment's colours. Crisp, macro-readable focus on fabric texture, drape, embroidery/print detail and cut. The model is elegantly groomed with a natural, poised, relaxed pose that presents the garment clearly — full drape, fit and details all readable. Polished premium-listing quality: clean, quiet, true to the garment.",
 };
 
 /**

--- a/src/lib/workspace-profile-server.ts
+++ b/src/lib/workspace-profile-server.ts
@@ -6,7 +6,7 @@ import type { WorkspaceProfile } from "./workspace-profile";
 export const getWorkspaceProfile = cache(async (workspaceId: string): Promise<WorkspaceProfile> => {
   const w = await prisma.workspace.findUnique({
     where: { id: workspaceId },
-    select: { industry: true, primaryUseCase: true, salesChannel: true },
+    select: { type: true, industry: true, primaryUseCase: true, salesChannel: true },
   });
-  return w ?? { industry: null, primaryUseCase: null, salesChannel: null };
+  return w ?? { type: null, industry: null, primaryUseCase: null, salesChannel: null };
 });

--- a/src/lib/workspace-profile.test.ts
+++ b/src/lib/workspace-profile.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { showsModelSurface, type WorkspaceProfile } from "./workspace-profile";
+
+const profile = (over: Partial<WorkspaceProfile>): WorkspaceProfile => ({
+  type: null,
+  industry: null,
+  primaryUseCase: null,
+  salesChannel: null,
+  ...over,
+});
+
+describe("showsModelSurface", () => {
+  it("always shows for apparel account types, regardless of legacy profile", () => {
+    expect(showsModelSurface(profile({ type: "APPAREL_ON_MODEL" }))).toBe(true);
+    expect(showsModelSurface(profile({ type: "FASHION_EDITORIAL", industry: "food_fmcg" }))).toBe(true);
+  });
+
+  it("falls back to the legacy profile for FMCG/default type (schema default can't distinguish a real choice)", () => {
+    expect(showsModelSurface(profile({ type: "FMCG_PRODUCT", industry: "apparel" }))).toBe(true);
+    expect(showsModelSurface(profile({ type: "FMCG_PRODUCT", primaryUseCase: "on_model" }))).toBe(true);
+    expect(showsModelSurface(profile({ type: "FMCG_PRODUCT", industry: "food_fmcg" }))).toBe(false);
+  });
+
+  it("shows everything on incomplete data (no type, no legacy answers)", () => {
+    expect(showsModelSurface(profile({}))).toBe(true);
+    expect(showsModelSurface(profile({ type: "FMCG_PRODUCT" }))).toBe(true);
+  });
+});

--- a/src/lib/workspace-profile.ts
+++ b/src/lib/workspace-profile.ts
@@ -29,6 +29,9 @@ export const PROFILE_CHANNELS = [
 ] as const;
 
 export interface WorkspaceProfile {
+  /** Canonical account type (Prisma WorkspaceType). Kept as string so this
+   * module stays client-safe. */
+  type: string | null;
   industry: string | null;
   primaryUseCase: string | null;
   salesChannel: string | null;
@@ -36,7 +39,11 @@ export interface WorkspaceProfile {
 
 /** Should this workspace see the AI Models surface (nav + on-model mode)? */
 export function showsModelSurface(profile: WorkspaceProfile): boolean {
-  // No profile yet → show everything (don't hide features on incomplete data).
+  // Apparel account types always get the Models surface.
+  if (profile.type === "APPAREL_ON_MODEL" || profile.type === "FASHION_EDITORIAL") return true;
+  // FMCG_PRODUCT is also the schema default, so it can't distinguish a real
+  // FMCG choice from a never-classified legacy workspace — fall back to the
+  // legacy profile answers, and show everything on incomplete data.
   if (!profile.industry && !profile.primaryUseCase) return true;
   return profile.industry === "apparel" || profile.primaryUseCase === "on_model";
 }

--- a/src/lib/workspace-type.ts
+++ b/src/lib/workspace-type.ts
@@ -1,0 +1,31 @@
+/**
+ * Workspace account types — the single client-safe source of the three
+ * customer segments. The ids mirror the Prisma `WorkspaceType` enum; keep them
+ * in lockstep. The type steers photography + concept direction end-to-end
+ * (see image-prompt.ts ON_MODEL_DIRECTION and the ACCOUNT STYLE brief block in
+ * generation-run.ts).
+ */
+
+export type WorkspaceTypeId = "FMCG_PRODUCT" | "APPAREL_ON_MODEL" | "FASHION_EDITORIAL";
+
+export const WORKSPACE_TYPES: readonly { id: WorkspaceTypeId; label: string; hint: string }[] = [
+  {
+    id: "FMCG_PRODUCT",
+    label: "Products & campaigns",
+    hint: "FMCG, packaged goods or any product SKU — festival, theme and custom-brief ad creatives",
+  },
+  {
+    id: "APPAREL_ON_MODEL",
+    label: "E-commerce apparel",
+    hint: "Clothing on AI models — clean premium catalog shots for product pages & listings",
+  },
+  {
+    id: "FASHION_EDITORIAL",
+    label: "Premium fashion",
+    hint: "Designer-grade apparel — styled fashion-campaign photoshoot look",
+  },
+] as const;
+
+export function isWorkspaceTypeId(v: unknown): v is WorkspaceTypeId {
+  return typeof v === "string" && WORKSPACE_TYPES.some((t) => t.id === v);
+}

--- a/src/trigger/generation-run.ts
+++ b/src/trigger/generation-run.ts
@@ -182,12 +182,13 @@ export const generationRun = task({
         customBrief: run.customBrief,
         customTitle: run.calendarEntry?.customTitle ?? null,
       });
-      // Account-type flavor: FASHION_EDITORIAL workspaces sell high-end
-      // apparel — every concept must read like a designer campaign, not a
-      // commerce listing. Threaded into the brief so concepting, brief QA and
-      // the prompt enhancer all inherit it.
+      // Account-type flavor, threaded into the brief so concepting, brief QA
+      // and the prompt enhancer all inherit it. FMCG_PRODUCT (the default) adds
+      // nothing — the base campaign behavior IS its style.
       if (workspace?.type === "FASHION_EDITORIAL") {
-        occasionBrief += `\n\n## ACCOUNT STYLE (non-negotiable)\nThis is a HIGH-FASHION EDITORIAL account. Every concept must look like a premium designer campaign or magazine editorial photoshoot (Vogue India energy): dramatic yet tasteful lighting, striking styled sets or locations, confident editorial model poses, luxury art direction, restrained color stories. Never mass-market catalogue styling, never discount-retail energy, never busy commerce clutter.`;
+        occasionBrief += `\n\n## ACCOUNT STYLE (non-negotiable)\nThis is a PREMIUM FASHION account. Every concept must look like a frame from a designer lookbook campaign: styled character energy (groomed model, confident expressive poses, tasteful accessories), environmental sets with real depth and props, directional natural or rim lighting with sculpted contrast, rich confident yet controlled colour grades, luxury art direction. Never flat catalogue styling, never mass-market or discount-retail energy, never busy commerce clutter.`;
+      } else if (workspace?.type === "APPAREL_ON_MODEL") {
+        occasionBrief += `\n\n## ACCOUNT STYLE (non-negotiable)\nThis is a PREMIUM E-COMMERCE APPAREL account. Every concept favors clean, elegant, minimal photography: soft diffused flattering light, warm neutral or calm architectural backdrops, muted harmonious palettes, the garment as the unmistakable hero with fabric and cut readable. Campaign or festival concepts stay tasteful, quiet and product-forward. Never gaudy retail energy, never cluttered maximalist scenes, never heavy props that compete with the clothing.`;
       }
       await updatePipeline(runId, (p) => { p.occasionBrief = occasionBrief; });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,44 +1,26 @@
-# 2026-07-22b — workspace model picker, multi-pose, aspect fix
-(prev round archived at tasks/todo-r4-archive.md)
+# 2026-07-23 — workspace account types (FMCG / e-com apparel / premium fashion)
+(prev round archived: tasks/todo-r4-archive.md; plan: ~/.ccpm/profiles/work/plans/warm-singing-comet.md)
 
 ## Decisions (from My Lord)
-- Model list: 7 — NB Pro, NB2, GPT Image 2, Seedream v4, Seedream v5 Lite, Qwen-Image (runware:108@1), Wan 2.7 (alibaba:wan@2.7-image). Workspace default, super-admin only.
-- Poses: multi-select REPLACE option count for on-model. M poses → M images, same model+garment. Hide "how many options" for on-model.
-- Aspect: editor "add format" re-renders NATIVE plate (image call) and CHARGES credits.
+- 3 segments = existing WorkspaceType enum (no migration). References: schein.in (e-com apparel), theblueman.net (premium fashion).
+- Settings: owner/admin (canManage) editable. Onboarding: 3-card picker REPLACES industry+usecase selects (keep salesChannel).
 
 ## Plan
-### F1 — Workspace image-model setting (super-admin only)
-- [ ] schema: Workspace.imageModel String?
-- [ ] runware.ts: add qwen_image, wan_2_7 to IMAGE_MODELS
-- [ ] provider.ts: runwareModel on params/variant; seedream path honors it; WORKSPACE_IMAGE_MODELS registry + resolveWorkspaceVariant(); labels
-- [ ] generation-run: select workspace.imageModel; resolve variant (soft-prefer, keep fallback)
-- [ ] actions/workspace.ts: setWorkspaceImageModel (requireSuperAdmin)
-- [ ] settings page + client: picker visible only to super admin
+- [x] src/lib/workspace-type.ts — shared WORKSPACE_TYPES metadata (client-safe)
+- [x] src/components/account-type-picker.tsx — shared radio-card picker
+- [x] admin new-workspace-dialog → use shared picker/metadata
+- [x] onboarding wizard: ProfileFields → AccountTypePicker (required) + salesChannel only
+- [x] brand.ts saveWorkspaceProfile: persist workspace.type + salesChannel; stop writing industry/useCase
+- [x] workspace-profile.ts showsModelSurface: type-first, legacy profile fallback (callers unchanged — profile carries type)
+- [x] workspace.ts setWorkspaceType (requireManager) + settings card (read-only for non-managers)
+- [x] image-prompt.ts: rewrite ON_MODEL_DIRECTION catalog (schein) + editorial (blueman)
+- [x] generation-run.ts: 3-way ACCOUNT STYLE brief block (FMCG none / APPAREL catalog / EDITORIAL campaign)
+- [x] tests: showsModelSurface matrix + updated direction-string assertions
+- [x] verify: tsc ✓ lint ✓ vitest 65 ✓; prod type audit done; DEVLOG entry written
 
-### F2 — Multi-pose (on-model)
-- [ ] schema: GenerationRun.modelPoses String[]
-- [ ] create-form: pose multi-select; hide optionCount for on-model; cost = poses×perConcept
-- [ ] generate.ts: parse modelPoses; on-model conceptCount = poses.length (min 1)
-- [ ] generation-run: on-model per-pose queue (1 concept × M poses); poseOverride → buildOnModelPrompt
-
-### F3 — Aspect native re-render + charge
-- [ ] paid-edits.ts: applyRenderAspect re-renders native plate via generateScene, not cover-crop
-- [ ] actions/editor.ts: renderNewAspect debits + insufficient handling
-- [ ] creative-edit.ts: render_aspect debited → catchError refunds
-- [ ] editor.tsx: "add format" copy reflects credit cost
-
-### Verify
-- [ ] tsc + lint + vitest + migrate + real e2e both kinds
-- [ ] DEVLOG entries; My Lord sets TRIGGER_ACCESS_TOKEN secret
-
-## Review — DONE (all 3 features built + verified)
-- F1 image-model picker: 7 models (NB Pro/NB2/GPT/Seedream v4/Seedream v5 Lite/Qwen-Image/Wan 2.7), super-admin-only in settings, soft-prefer with cascade kept. 4 new unit tests incl. fallback-model-isolation guard.
-- F2 multi-pose: verified live — 2 poses → 2 creatives, each with its own pose (run 8ac7da08). Option picker hidden for on-model.
-- F3 aspect native re-render: verified live — new 1:1 got a native plate (0-1x1.png) recorded in aspectPlateKeys, not a crop. Now charges credits (regen cost); refund on failure both paths.
-- Verify: tsc ✓, lint ✓, vitest 62 ✓, real e2e both kinds ✓ (in-scene 1.9m, on-model 3.3m).
-- Migrations 20260722115500 (cutout) + 20260722133655 (imageModel+modelPoses) applied to prod DB — nullable/backward-compatible, old prod code unaffected.
-
-## State / open
-- ALL of this session's work is UNCOMMITTED (last commit 72b6ed1). Batch A (timeout/cutouts/e2e/CI) was deployed to prod last part but not committed; Batch B (these 3 features) is neither committed nor deployed.
-- Awaiting My Lord: test → then commit (retroactive-commit-history) + deploy (Trigger prod + Vercel prod).
-- Still pending: My Lord sets TRIGGER_ACCESS_TOKEN gh secret (dashboard PAT) — blocks CI trigger-deploy + e2e worker.
+## Review — DONE
+- All UI reuses one AccountTypePicker (admin dialog, onboarding, settings). Zero DB migrations.
+- Live smoke: settings picker persists to DB + toast + revert works (dev workspace flipped APPAREL_ON_MODEL→back); onboarding renders 3-card picker, required radio blocks submit.
+- Concept + render prompts now 3-way: FMCG unchanged; APPAREL_ON_MODEL = schein-anchored (soft diffused light, warm beige architectural sets, garment hero); FASHION_EDITORIAL = blueman-anchored (styled character, environmental depth, rim light, rich grade).
+- FLAGS for My Lord: (1) prod workspaces "Synerix Apparel" + "E2E Tests" are typed FMCG_PRODUCT but are apparel — fix via new settings card. (2) Pre-existing: image-model Select shows raw "__default__" instead of its label. (3) dev:next left running on :6969 for your testing.
+- UNCOMMITTED — My Lord tests, then commit via retroactive-commit-history.


### PR DESCRIPTION
## What

Wires the dormant `WorkspaceType` enum end-to-end so the three customer segments get distinct generation styles:

- **Onboarding**: required 3-card account-type picker (replaces the Industry / Mainly-creating selects; "You sell via" kept). Persists `workspace.type`.
- **Settings**: new Account type card — owner/admin editable, read-only for other members.
- **Photography direction** (`ON_MODEL_DIRECTION`) rewritten from live references: schein.in (e-com apparel — soft diffused daylight, warm beige architectural sets, garment-hero catalog) and theblueman.net (premium fashion — styled character, environmental depth, rim light, rich grade).
- **Concept briefs**: 3-way ACCOUNT STYLE block (FMCG = unchanged base behavior) so concepting, brief QA and the enhancer inherit the account's style.
- Models surface gating keys on account type first, with the legacy profile fallback for pre-type workspaces.
- Shared `WORKSPACE_TYPES` metadata + `AccountTypePicker` reused across admin dialog, onboarding and settings.

No DB migrations — the enum and column already existed.

## Verification

- tsc, lint, vitest 65/65 (new `showsModelSurface` matrix + updated prompt assertions)
- Live smoke on dev: settings picker persists + reverts; onboarding renders the picker and blocks submit without a choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)