### PR TITLE
feat: lite catalog pipeline, stall recovery, and cost tooling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,12 @@ jobs:
       MODEL_RESEARCH: claude-haiku-4-5-20251001
       GEMINI_IMAGE_MODEL: gemini-3.1-flash-image
       IMAGE_PROVIDER: gemini
+      # e2e asserts the pipeline completes, not that the render is faithful, so
+      # fidelity QA never re-renders here — a corrective render is a full extra
+      # image and was the single biggest line in the suite's bill ($0.20 vs
+      # $0.08 on the same run shape).
+      PACK_QA_MAX_RETRIES: "0"
+      LITE_QA_MAX_RETRIES: "0"
     steps:
       - uses: actions/checkout@v4
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -67,6 +67,35 @@ New entries go at the **top** of the Log section (reverse chronological).
 
 ## Log
 
+### 2026-07-25 — Lite pipeline for PLAIN on-model (6× cheaper per catalog image) + OOM/stall recovery
+
+- Type: feature + fix
+- Scope: src/lib/pipeline/catalog-concepts.ts (new), src/trigger/generation-run.ts, src/trigger/heal-runs.ts (new), src/lib/run-heal.ts (new), src/lib/editor/paid-edits.ts, src/lib/pipeline/typography.ts, src/lib/pipeline/model-qa.ts, src/lib/image/runware.ts, src/app/(admin)/admin/costs/page.tsx, src/app/(app)/studio/[runId]/{page,studio-canvas}.tsx, src/trigger/creative-edit.ts, .github/workflows/e2e.yml, tests
+
+Reasoning / RCA / research:
+    - Trigger: an apparel client wants 800+ images at ≤ $0.5 each; measured unit cost was $0.34–$0.52. Read the real numbers out of `api_cost_log` rather than estimating — worst prod run: on-model renders $0.402 (NB Pro $0.134 × 3 = 1 render + 2 fidelity retries), concepts (Opus) $0.085, enhancer $0.020, brief-QA $0.013, model-QA $0.004.
+    - Key finding: on a PLAIN on-model run the compositor renders NO text and NO logo (`plainMode`), so the concept LLM's four-language copy, big idea, archetype and typography spec are generated and then discarded. ~$0.118/creative and ~45s of latency bought nothing. The variation a catalog needs is framing, not storytelling — and a fixed shot list holds consistency across an 800-image drop better than an LLM can.
+    - Gated the lite path on `ON_MODEL + PLAIN`, NOT on account type: an APPAREL_ON_MODEL workspace still runs branded festival campaigns, and those legitimately need concepting. My Lord chose the narrower gate.
+    - Bake-off (4 garments × 4 models, real runs, ~$1.27 total): NB2 ($0.06) matched or beat NB Pro ($0.134) on 3 of 4 garments; on the fourth it rendered a hip-length tunic as an ankle-length gown and model-QA passed it — so the QA prompt now judges HEM LENGTH and invented embellishment explicitly. Seedream v4 ($0.03) hallucinated beadwork onto a dupatta border and shortened sleeves; gpt-image-2 cropped the model's head (it has no native 4:5 and the crop ate the head). Conclusion: NB2 as the apparel default with the cascade behind it, not Seedream.
+    - Found while bake-offing: EVERY on-model render on a Runware model was failing with `invalidPositivePrompt` — our on-model prompt is capped at 4500 chars and Runware rejects that. Trimming from the middle (not the end) keeps the two-reference fidelity contract in the head and the craft floors in the tail; only the scene body is lossy.
+    - Prod OOM (TASK_PROCESS_OOM_KILLED, 3-pose 9:16 run): generation-run had no `machine` preset, so it ran on small-1x = 0.5 GB while holding several multi-megapixel PNGs per concurrent concept (plate + composite + sharp raster + base64 copies of 3 images for QA). An OOM is a process kill, so `catchError` never ran → the row stayed RENDERING, credits stayed debited, and the studio spun forever.
+    - The spinner had a second, independent cause: studio-canvas derived liveness ONLY from `run.metadata.status`, which the task writes itself. A dead worker can never write it. The Trigger run's own status (CRASHED/SYSTEM_FAILURE/…) was already in hand and ignored.
+    - Stall recovery also only ran when someone loaded that run's studio page (and only after 30 min), so a user who closed the tab kept the spinner and the credits indefinitely.
+
+Implementation summary:
+    - `catalog-concepts.ts`: 6-shot table (framing/pose/backdrop only — craft floors still come from buildOnModelPrompt) + a neutral brief for pose-driven runs. Lite branch skips concepting, brief-QA, the enhancer and the brand-intel refresh.
+    - Fidelity-QA retry budget is now per-path (`LITE_QA_MAX_RETRIES`, default 1 vs 2) and the verdict is finally persisted for PLAIN creatives — the highest-volume path had no measurable QA outcome.
+    - `machine: medium-2x` on generation-run, `medium-1x` on creative-edit; shared `healStalledRun`/`healAllStalledRuns` + a 10-minute `heal-stalled-runs` scheduled task; studio treats a dead Trigger run as terminal and shows the failure panel.
+    - Workspace image-model pin now honoured by the editor paths (baked-text swap, both regen paths, the typography pass) — they hardcoded `tier: "hero"` and silently billed NB Pro to workspaces pinned to a cheap model.
+    - e2e: `PACK_QA_MAX_RETRIES=0` / `LITE_QA_MAX_RETRIES=0` — corrective re-renders were the suite's largest line ($0.20 vs $0.08 on the same run shape).
+    - Admin costs list gained "Spend by pipeline stage · last 30 days" with share-of-total, plus a visible affordance on run rows (the per-run stage split existed but the rows looked unclickable).
+    - Verified: tsc/lint clean, 70 vitest pass; 4 real bake-off runs on prod data confirmed `lite="plain-on-model"` with zero concepting spend (LLM cost per creative $0.118 → $0.001); the stalled prod run was healed and its 6 credits refunded (balance 76 → 82).
+
+Follow-ups deferred:
+    - "Compare" image-model pref + a workspace pin = 2× credits debited but one render delivered (generate.ts:149 vs generation-run.ts:147). Needs a product decision.
+    - The apparel workspace's only READY AI model is male while its garments are womenswear — every bake-off render put a man in a women's anarkali. Model library needs female models before the client drop.
+    - generate-model.ts still renders AI models on NB Pro ($0.134, one-time per model).
+
 ### 2026-07-23 — Workspace account types drive photography style (FMCG / e-com apparel / premium fashion)
 
 - Type: feature

--- a/src/app/(admin)/admin/costs/page.tsx
+++ b/src/app/(admin)/admin/costs/page.tsx
@@ -47,7 +47,7 @@ export default async function AdminCostsPage({
 
   const d30 = new Date(Date.now() - 30 * 864e5);
 
-  const [runs, totalRuns, allTime, last30, bySource] = await Promise.all([
+  const [runs, totalRuns, allTime, last30, bySource, byStage] = await Promise.all([
     prisma.generationRun.findMany({
       orderBy: { createdAt: "desc" },
       skip: (page - 1) * PAGE_SIZE,
@@ -74,6 +74,15 @@ export default async function AdminCostsPage({
       _sum: { usd: true },
       orderBy: { _sum: { usd: "desc" } },
     }),
+    // Which pipeline step actually burns the money, across every run in the
+    // window (the per-run split lives on the run detail page).
+    prisma.apiCostLog.groupBy({
+      by: ["stage", "kind", "model"],
+      where: { createdAt: { gte: d30 } },
+      _sum: { usd: true, imageCount: true },
+      _count: { _all: true },
+      orderBy: { _sum: { usd: "desc" } },
+    }),
   ]);
 
   // ONE groupBy for the whole page's per-run totals — never N queries.
@@ -87,6 +96,8 @@ export default async function AdminCostsPage({
     : [];
   const usdByRun = new Map(runSums.map((r) => [r.runId, num(r._sum.usd)]));
 
+  const stageTotal = byStage.reduce((s, g) => s + num(g._sum.usd), 0);
+  void stageTotal; // table lands in the next commit
   const totalPages = Math.max(1, Math.ceil(totalRuns / PAGE_SIZE));
 
   const stats = [
@@ -122,7 +133,13 @@ export default async function AdminCostsPage({
         </p>
       )}
 
-      <div className="mt-6 overflow-x-auto rounded-lg border border-border">
+      <h2 className="mt-8 text-sm font-semibold">
+        Runs
+        <span className="ml-2 font-normal text-xs text-muted-foreground">
+          open a run for its own stage-by-stage split
+        </span>
+      </h2>
+      <div className="mt-2 overflow-x-auto rounded-lg border border-border">
         <table className="w-full min-w-max text-sm">
           <thead>
             <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">

--- a/src/app/(admin)/admin/costs/page.tsx
+++ b/src/app/(admin)/admin/costs/page.tsx
@@ -97,7 +97,6 @@ export default async function AdminCostsPage({
   const usdByRun = new Map(runSums.map((r) => [r.runId, num(r._sum.usd)]));
 
   const stageTotal = byStage.reduce((s, g) => s + num(g._sum.usd), 0);
-  void stageTotal; // table lands in the next commit
   const totalPages = Math.max(1, Math.ceil(totalRuns / PAGE_SIZE));
 
   const stats = [
@@ -133,6 +132,51 @@ export default async function AdminCostsPage({
         </p>
       )}
 
+      {byStage.length > 0 && (
+        <>
+          <h2 className="mt-8 text-sm font-semibold">
+            Spend by pipeline stage · last 30 days
+            <span className="ml-2 font-normal text-xs text-muted-foreground">
+              share of {usd2(stageTotal)}
+            </span>
+          </h2>
+          <div className="mt-2 overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-max text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  <th className="px-4 py-2.5">Stage</th>
+                  <th className="px-4 py-2.5">Kind</th>
+                  <th className="px-4 py-2.5">Model</th>
+                  <th className="px-4 py-2.5 text-right">Calls</th>
+                  <th className="px-4 py-2.5 text-right">USD</th>
+                  <th className="px-4 py-2.5 text-right">Share</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {byStage.map((s) => {
+                  const usd = num(s._sum.usd);
+                  const share = stageTotal > 0 ? (usd / stageTotal) * 100 : 0;
+                  return (
+                    <tr key={`${s.stage}|${s.kind}|${s.model}`}>
+                      <td className="px-4 py-2.5 font-medium">{s.stage}</td>
+                      <td className="px-4 py-2.5">
+                        <Badge variant="outline">{s.kind}</Badge>
+                      </td>
+                      <td className="px-4 py-2.5 text-muted-foreground">{s.model}</td>
+                      <td className="px-4 py-2.5 text-right tabular-nums">{s._count._all}</td>
+                      <td className="px-4 py-2.5 text-right font-medium tabular-nums">{usd4(usd)}</td>
+                      <td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
+                        {share.toFixed(1)}%
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
       <h2 className="mt-8 text-sm font-semibold">
         Runs
         <span className="ml-2 font-normal text-xs text-muted-foreground">
@@ -151,11 +195,12 @@ export default async function AdminCostsPage({
               <th className="px-4 py-2.5">Bake-off</th>
               <th className="px-4 py-2.5 text-right">Credits</th>
               <th className="px-4 py-2.5 text-right">API USD</th>
+              <th className="px-4 py-2.5" />
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
             {runs.map((run) => (
-              <tr key={run.id} className="relative hover:bg-muted/50">
+              <tr key={run.id} className="relative cursor-pointer hover:bg-muted/50">
                 <td className="px-4 py-2.5 whitespace-nowrap text-muted-foreground">
                   <Link href={`/admin/costs/${run.id}`} className="absolute inset-0" aria-label="Run cost detail" />
                   {dateFmt.format(run.createdAt)}
@@ -173,6 +218,7 @@ export default async function AdminCostsPage({
                 <td className="px-4 py-2.5 text-right font-medium tabular-nums">
                   {usd4(usdByRun.get(run.id) ?? 0)}
                 </td>
+                <td className="px-4 py-2.5 text-right text-muted-foreground">→</td>
               </tr>
             ))}
           </tbody>

--- a/src/app/(app)/studio/[runId]/page.tsx
+++ b/src/app/(app)/studio/[runId]/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/db";
 import { getSignedUrls, getSignedThumbUrls } from "@/lib/storage";
 import { BAKEOFF_VARIANTS, IMAGE_MODEL_LABELS } from "@/lib/image/provider";
 import { loadEditorProps } from "@/lib/editor-data";
+import { healStalledRun } from "@/lib/run-heal";
 import { StudioCanvas } from "./studio-canvas";
 import type { PipelineState } from "@/lib/pipeline/schemas";
 
@@ -38,31 +39,13 @@ export default async function RunPage({
   });
   if (!run) notFound();
 
-  // Self-healing: a run stuck non-terminal for 30+ min means the worker died;
-  // fail it and refund undelivered creatives (its catchError never fired).
-  if (!TERMINAL.includes(run.status) && Date.now() - run.startedAt.getTime() > 30 * 60 * 1000) {
-    const { CREDIT_COSTS } = await import("@/lib/ai/models");
-    const { reconcileRunRefund } = await import("@/lib/credits");
-    const delivered = run.creatives.filter((cr) => cr.status === "READY").length;
-    const nextStatus = delivered > 0 ? "PARTIAL" : "FAILED";
-    // This runs on GET render, so two concurrent tabs/refreshes can enter here
-    // together. A conditional transition (only flip if still non-terminal) means
-    // exactly ONE render performs the recovery; the refund is additionally
-    // idempotent (reconciled against prior REFUND for this run), so a race can
-    // never inflate credits.
-    const flipped = await prisma.generationRun.updateMany({
-      where: { id: run.id, status: { notIn: ["COMPLETE", "PARTIAL", "FAILED"] } },
-      data: { status: nextStatus, finishedAt: new Date(), error: "Run stalled (worker lost) — auto-failed after 30 min" },
-    });
-    if (flipped.count > 0 && Number(run.creditsDebited) > 0) {
-      await reconcileRunRefund({
-        workspaceId: run.workspaceId,
-        generationRunId: run.id,
-        owedRefund: Number(run.creditsDebited) - delivered * CREDIT_COSTS.perConcept,
-        note: "Run stalled — automatic refund",
-      });
-    }
-    run.status = nextStatus;
+  // Self-healing: a dead worker (OOM kill / crash) never runs catchError, so
+  // the row would sit non-terminal forever. Heal the run being viewed here and
+  // sweep the rest on a schedule (trigger/heal-runs.ts) — the recovery is
+  // idempotent and race-safe, so both paths can fire.
+  if (!TERMINAL.includes(run.status)) {
+    const healed = await healStalledRun(run.id);
+    if (healed) run.status = healed;
   }
 
   const pipeline = (run.pipeline ?? {}) as PipelineState;

--- a/src/app/(app)/studio/[runId]/studio-canvas.tsx
+++ b/src/app/(app)/studio/[runId]/studio-canvas.tsx
@@ -57,6 +57,13 @@ export function StudioCanvas(props: {
     enabled: Boolean(props.triggerRunId && props.publicToken),
   });
   const liveStatus = (run?.metadata?.status as string) ?? props.status;
+  // The task mirrors its own status into metadata — but a killed worker (OOM,
+  // crash, timeout) never gets to write it, which left this screen spinning
+  // forever. The Trigger run's OWN status still reports the death, so treat it
+  // as terminal here rather than waiting for metadata that will never arrive.
+  const workerDead = Boolean(
+    run && ["FAILED", "CRASHED", "SYSTEM_FAILURE", "INTERRUPTED", "TIMED_OUT", "EXPIRED", "CANCELED"].includes(run.status),
+  );
   const done = Number(run?.metadata?.done ?? 0);
   const conceptCount = Number(run?.metadata?.conceptCount ?? props.conceptCount ?? 0);
 
@@ -67,7 +74,9 @@ export function StudioCanvas(props: {
   const hasRealtime = Boolean(props.triggerRunId && props.publicToken);
   const lastProgress = useRef({ done: 0, status: props.status });
   useEffect(() => {
-    if (TERMINAL.includes(liveStatus)) {
+    if (TERMINAL.includes(liveStatus) || workerDead) {
+      // A dead worker leaves the DB row non-terminal until the healer flips it;
+      // refreshing re-renders the page, which heals it and refunds.
       router.refresh();
       return;
     }
@@ -81,14 +90,14 @@ export function StudioCanvas(props: {
     }
     const interval = setInterval(() => router.refresh(), 15_000);
     return () => clearInterval(interval);
-  }, [liveStatus, done, hasRealtime, router]);
+  }, [liveStatus, done, hasRealtime, workerDead, router]);
 
   // Failed work items never become selectable options — show them as such
   // instead of leaving eternal "crafting…" skeletons (or hiding them entirely
   // on PARTIAL runs).
   const failedItems = Object.entries(props.conceptStatus).filter(([, s]) => s === "failed");
   const pendingSlots = Math.max(0, conceptCount - props.concepts.length - failedItems.length);
-  const generating = !props.isTerminal && !TERMINAL.includes(liveStatus);
+  const generating = !props.isTerminal && !TERMINAL.includes(liveStatus) && !workerDead;
 
   return (
     <div className="flex flex-col gap-4 lg:flex-row lg:gap-5">
@@ -193,10 +202,12 @@ export function StudioCanvas(props: {
       <div className="min-w-0 flex-1">
         {props.editorProps ? (
           <CreativeEditor key={props.editorProps.creativeId} {...props.editorProps} />
-        ) : props.failed ? (
+        ) : props.failed || workerDead ? (
           <div className="flex min-h-[60vh] flex-col items-center justify-center rounded-2xl border border-destructive/30 bg-destructive/5 p-8 text-center">
             <p className="font-medium text-destructive">This run failed</p>
-            <p className="mt-1 max-w-sm text-sm text-destructive/80">{props.error ?? "Something went wrong."} Your credits were refunded.</p>
+            <p className="mt-1 max-w-sm text-sm text-destructive/80">
+              {props.error ?? "Something went wrong."} Your credits were refunded.
+            </p>
             <Link href="/studio" className="mt-4 text-sm font-medium text-primary hover:underline">Start a new one</Link>
           </div>
         ) : (

--- a/src/app/(app)/studio/[runId]/studio-canvas.tsx
+++ b/src/app/(app)/studio/[runId]/studio-canvas.tsx
@@ -206,7 +206,7 @@ export function StudioCanvas(props: {
           <div className="flex min-h-[60vh] flex-col items-center justify-center rounded-2xl border border-destructive/30 bg-destructive/5 p-8 text-center">
             <p className="font-medium text-destructive">This run failed</p>
             <p className="mt-1 max-w-sm text-sm text-destructive/80">
-              {props.error ?? "Something went wrong."} Your credits were refunded.
+              {props.error ?? (workerDead ? "The generation worker stopped unexpectedly." : "Something went wrong.")} Your credits were refunded.
             </p>
             <Link href="/studio" className="mt-4 text-sm font-medium text-primary hover:underline">Start a new one</Link>
           </div>

--- a/src/lib/editor/paid-edits.ts
+++ b/src/lib/editor/paid-edits.ts
@@ -421,6 +421,7 @@ export async function applyRegenInstruction(
   const tracker = new CostTracker();
 
   try {
+    const model = await workspaceModelParams(workspaceId);
     if (baked && concept.scenePlateKey) {
       // Two-pass creatives: edit the WORDLESS scene, then re-set typography —
       // the instruction edit never has to fight existing type pixels.
@@ -428,7 +429,7 @@ export async function applyRegenInstruction(
       const gen = await generateScene({
         prompt: `Edit this advertising scene: ${note}. Keep everything else identical — same product, same composition, same palette (${concept.paletteHexes.join(", ")}). No text, no letters, no logos, no watermarks (only the product's own packaging print).`,
         aspect,
-        tier: "hero", // paid edit — premium model, same bar as generation
+        ...model, // workspace pin, else the premium tier (same bar as generation)
         references: [{ buffer: scenePlate, mime: "image/png" }],
       });
       tracker.addImage(gen.costModel, "editor-regen");
@@ -444,6 +445,7 @@ export async function applyRegenInstruction(
         typographySpec: concept.typographySpec,
         paletteHexes: concept.paletteHexes,
         aspect,
+        model,
         tracker,
       });
       if (!typed.ok) {
@@ -479,7 +481,7 @@ export async function applyRegenInstruction(
     const gen = await generateScene({
       prompt: `Edit this advertising scene: ${note}. Keep everything else identical — same product, same composition, same palette (${concept.paletteHexes.join(", ")}). ${textRule}`,
       aspect,
-      tier: "hero", // paid edit — premium model, same bar as generation
+      ...model, // workspace pin, else the premium tier (same bar as generation)
       references: [{ buffer: currentPlate, mime: "image/png" }],
     });
     tracker.addImage(gen.costModel, "editor-regen");

--- a/src/lib/editor/paid-edits.ts
+++ b/src/lib/editor/paid-edits.ts
@@ -31,6 +31,24 @@ export function isBaked(creative: { concept: unknown }): boolean {
   return (creative.concept as ConceptWithTypography)?.typographyMode === "baked";
 }
 
+/**
+ * The workspace's pinned image model as generateScene params (soft-prefer, so
+ * the resilience cascade stays behind it). EVERY paid image call routes through
+ * this: a workspace pinned to a cheap model must not be silently billed the
+ * premium default just because the call happens in the editor. With no pin, the
+ * premium tier stands — a paid edit holds the same bar as generation.
+ */
+export async function workspaceModelParams(workspaceId: string) {
+  const ws = await prisma.workspace.findUnique({
+    where: { id: workspaceId },
+    select: { imageModel: true },
+  });
+  const v = resolveWorkspaceImageModel(ws?.imageModel);
+  return v
+    ? { provider: v.provider, tier: v.tier, softPrefer: true as const, runwareModel: v.runwareModel }
+    : { tier: "hero" as const };
+}
+
 export async function loadOwnedCreative(creativeId: string, workspaceId: string) {
   const creative = await prisma.creative.findFirst({
     where: { id: creativeId, brand: { workspaceId }, deletedAt: null },

--- a/src/lib/editor/paid-edits.ts
+++ b/src/lib/editor/paid-edits.ts
@@ -293,6 +293,7 @@ export async function applyBakedTextSwap(
       typographySpec?: string;
       paletteHexes?: string[];
     };
+    const model = await workspaceModelParams(workspaceId);
     let newPlate: Buffer;
 
     if (concept.scenePlateKey) {
@@ -302,6 +303,7 @@ export async function applyBakedTextSwap(
       const typed = await applyTypographyPass({
         scenePlate,
         tracker,
+        model,
         headline: next.headline,
         cta: next.cta,
         language: next.language,
@@ -334,7 +336,7 @@ export async function applyBakedTextSwap(
           (next.cta ? ` and the call-to-action "${next.cta}"` : "") +
           ` — ${script[next.language] ?? "English"}, spelled EXACTLY as given, every letter and diacritic correct, in the same premium advertising-typography style, position and size as the text it replaces. Keep EVERYTHING else identical: same scene, product, people, lighting, palette. No other text.`,
         aspect: (creative.masterAspect as Aspect) ?? "4:5",
-        tier: "hero", // paid edit — premium model, same bar as generation
+        ...model, // workspace pin, else the premium tier (same bar as generation)
         references: [{ buffer: currentPlate, mime: "image/png" }],
       });
       tracker.addImage(gen.costModel, "editor-baked-text");

--- a/src/lib/image/provider.test.ts
+++ b/src/lib/image/provider.test.ts
@@ -5,6 +5,7 @@ import {
   resolveWorkspaceImageModel,
   WORKSPACE_IMAGE_MODELS,
 } from "./provider";
+import { fitRunwarePrompt } from "./runware";
 import { ASPECT_DIMENSIONS } from "@/lib/composition/types";
 
 describe("resolveSceneChain — quality-first fallback cascade", () => {
@@ -93,5 +94,20 @@ describe("closestGptSize — single-sourced from ASPECT_DIMENSIONS", () => {
       const sizePortrait = w < h;
       expect(sizePortrait).toBe(canvasPortrait); // portrait canvas → portrait size
     }
+  });
+});
+
+describe("fitRunwarePrompt", () => {
+  it("keeps short prompts untouched", () => {
+    expect(fitRunwarePrompt("short prompt", 100)).toBe("short prompt");
+  });
+
+  it("trims the middle so the fidelity head and craft-floor tail both survive", () => {
+    const head = "IMAGE 1 is the MODEL. ".padEnd(300, "h");
+    const tail = "Framing: ONE single photograph.".padStart(300, "t");
+    const fitted = fitRunwarePrompt(`${head}${"x".repeat(4000)}${tail}`, 500);
+    expect(fitted.length).toBeLessThanOrEqual(500);
+    expect(fitted).toMatch(/^IMAGE 1 is the MODEL\./);
+    expect(fitted).toMatch(/ONE single photograph\.$/);
   });
 });

--- a/src/lib/image/runware.ts
+++ b/src/lib/image/runware.ts
@@ -122,7 +122,7 @@ export async function generateImage(p: GenerateImageParams): Promise<GenerateIma
   const task: Record<string, unknown> = {
     taskType: "imageInference",
     taskUUID,
-    positivePrompt: p.prompt,
+    positivePrompt: fitRunwarePrompt(p.prompt),
     model: modelId,
     width,
     height,
@@ -132,7 +132,7 @@ export async function generateImage(p: GenerateImageParams): Promise<GenerateIma
   };
   if (p.negativePrompt) {
     if (NO_NEGATIVE_PROMPT.has(modelId)) {
-      task.positivePrompt = `${p.prompt}\n\nAvoid: ${p.negativePrompt}`.slice(0, 9000);
+      task.positivePrompt = fitRunwarePrompt(`${p.prompt}\n\nAvoid: ${p.negativePrompt}`);
     } else {
       task.negativePrompt = p.negativePrompt;
     }

--- a/src/lib/image/runware.ts
+++ b/src/lib/image/runware.ts
@@ -95,6 +95,23 @@ export interface GenerateImageResult {
   taskUUID: string;
 }
 
+/**
+ * Runware rejects a long positivePrompt outright (`invalidPositivePrompt`),
+ * which silently made EVERY on-model render fail on Runware models — our
+ * on-model prompt is capped at 4500 chars. Trim from the MIDDLE: the head
+ * carries the two-reference fidelity contract and the tail carries the craft
+ * floors (single figure, framing, safe zones); only the scene body in between
+ * can be lost without breaking the render.
+ */
+const RUNWARE_PROMPT_MAX = Number(process.env.RUNWARE_PROMPT_MAX ?? 2900);
+
+export function fitRunwarePrompt(prompt: string, max = RUNWARE_PROMPT_MAX): string {
+  if (prompt.length <= max) return prompt;
+  const head = Math.floor(max * 0.35);
+  const tail = max - head - 5;
+  return `${prompt.slice(0, head)}\n...\n${prompt.slice(-tail)}`;
+}
+
 export async function generateImage(p: GenerateImageParams): Promise<GenerateImageResult> {
   const apiKey = process.env.RUNWARE_API_KEY;
   if (!apiKey) throw new Error("RUNWARE_API_KEY missing");

--- a/src/lib/pipeline/catalog-concepts.test.ts
+++ b/src/lib/pipeline/catalog-concepts.test.ts
@@ -8,4 +8,11 @@ describe("buildCatalogConcepts", () => {
     expect(new Set(concepts.map((c) => c.imagePrompt)).size).toBe(4);
     expect(new Set(concepts.map((c) => c.name)).size).toBe(4);
   });
+
+  it("collapses to one neutral brief when poses drive the variation", () => {
+    const [concept, ...rest] = buildCatalogConcepts({ count: 4, poseDriven: true });
+    expect(rest).toHaveLength(0);
+    // A pose-driven body must not fight the run's own pose instruction.
+    expect(concept.imagePrompt).not.toMatch(/stride|seated|turned/i);
+  });
 });

--- a/src/lib/pipeline/catalog-concepts.test.ts
+++ b/src/lib/pipeline/catalog-concepts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildCatalogConcepts } from "./catalog-concepts";
+import { buildOnModelPrompt } from "./image-prompt";
 
 describe("buildCatalogConcepts", () => {
   it("gives every requested concept a distinct shot", () => {
@@ -14,5 +15,14 @@ describe("buildCatalogConcepts", () => {
     expect(rest).toHaveLength(0);
     // A pose-driven body must not fight the run's own pose instruction.
     expect(concept.imagePrompt).not.toMatch(/stride|seated|turned/i);
+  });
+
+  it("renders a prompt carrying the catalog craft floors and no copy", () => {
+    const [concept] = buildCatalogConcepts({ count: 1, palette: ["#f5f1ea"] });
+    const prompt = buildOnModelPrompt({ concept, aspect: "4:5", direction: "catalog", plain: true });
+    expect(prompt).toMatch(/premium e-commerce showcase/i);
+    expect(prompt).toMatch(/STRICT E-COMMERCE SHOWCASE/);
+    expect(prompt).toContain(concept.imagePrompt);
+    expect(concept.copy.en.headline).toBe("");
   });
 });

--- a/src/lib/pipeline/catalog-concepts.test.ts
+++ b/src/lib/pipeline/catalog-concepts.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { buildCatalogConcepts } from "./catalog-concepts";
+
+describe("buildCatalogConcepts", () => {
+  it("gives every requested concept a distinct shot", () => {
+    const concepts = buildCatalogConcepts({ count: 4 });
+    expect(concepts).toHaveLength(4);
+    expect(new Set(concepts.map((c) => c.imagePrompt)).size).toBe(4);
+    expect(new Set(concepts.map((c) => c.name)).size).toBe(4);
+  });
+});

--- a/src/lib/pipeline/catalog-concepts.ts
+++ b/src/lib/pipeline/catalog-concepts.ts
@@ -7,9 +7,16 @@ import type { CreativeConcept } from "./schemas";
  * Why no LLM here: a PLAIN on-model creative ships the bare model+garment
  * photograph — the compositor renders NO headline, subhead, CTA or logo (see
  * `plainMode` in generation-run). The concept LLM's entire output except the
- * scene line is discarded, so paying for concepting + brief QA + prompt polish
- * bought nothing but latency. The variation a catalog needs is framing, not
- * storytelling.
+ * scene line (four-language copy, big idea, archetype, typography spec) is
+ * discarded, so paying Opus for concepting + Sonnet for brief QA + Opus for
+ * prompt polish bought nothing but latency (~$0.12 and ~45s per creative,
+ * measured on prod runs). The variation a catalog actually needs is framing,
+ * not storytelling, and a fixed shot list gives a client's 800-image drop the
+ * consistency an LLM cannot hold across runs.
+ *
+ * These bodies deliberately carry ONLY the shot: pose, camera, crop, backdrop.
+ * The craft floors (garment fidelity, light quality, single-figure framing,
+ * the schein-anchored catalog direction) are appended by buildOnModelPrompt.
  */
 
 interface Shot {
@@ -17,6 +24,8 @@ interface Shot {
   body: string;
 }
 
+/** Backdrops stay in one warm-neutral family on purpose — a catalog reads as a
+ * set. The variation axis is framing and pose. */
 const SHOTS: Shot[] = [
   {
     name: "Front hero",
@@ -29,6 +38,18 @@ const SHOTS: Shot[] = [
   {
     name: "In motion",
     body: "Full-length walking frame. The model steps naturally toward camera mid-stride, the garment carrying real motion in its fabric and hem, arms swinging loosely, gaze forward. Warm beige studio backdrop kept quiet so the movement of the cloth reads clearly.",
+  },
+  {
+    name: "Side profile",
+    body: "Full-length side frame. The model stands turned away from camera at roughly forty-five degrees, looking off-frame, so the garment's silhouette, side seams, sleeve line and back drape all read. Sand-toned wall with a soft directional shadow falling behind the figure.",
+  },
+  {
+    name: "Seated",
+    body: "Full-length seated frame. The model sits on a simple pale wooden block, posture relaxed and upright, hands easy, one leg extended, so the garment's drape falls naturally across the lap and shoulders. Warm neutral studio backdrop, uncluttered.",
+  },
+  {
+    name: "Architectural",
+    body: "Full-length environmental frame. The model stands beside a quiet beige architectural detail — a subtle plaster arch or a low step riser — lit by soft window light from one side, posture poised and still. Minimal set with gentle depth, nothing competing with the clothing.",
   },
 ];
 

--- a/src/lib/pipeline/catalog-concepts.ts
+++ b/src/lib/pipeline/catalog-concepts.ts
@@ -1,0 +1,61 @@
+import type { CreativeConcept } from "./schemas";
+
+/**
+ * Deterministic concept briefs for PLAIN on-model runs (e-commerce apparel
+ * product-page shots).
+ *
+ * Why no LLM here: a PLAIN on-model creative ships the bare model+garment
+ * photograph — the compositor renders NO headline, subhead, CTA or logo (see
+ * `plainMode` in generation-run). The concept LLM's entire output except the
+ * scene line is discarded, so paying for concepting + brief QA + prompt polish
+ * bought nothing but latency. The variation a catalog needs is framing, not
+ * storytelling.
+ */
+
+interface Shot {
+  name: string;
+  body: string;
+}
+
+const SHOTS: Shot[] = [
+  {
+    name: "Front hero",
+    body: "Full-length straight-on hero frame. The model stands facing camera in a relaxed, symmetrical stance, weight settled on one leg, arms loose at the sides, chin level, calm confident expression. Warm off-white seamless studio backdrop with a soft floor gradient and a gentle contact shadow.",
+  },
+  {
+    name: "Three-quarter turn",
+    body: "Full-length three-quarter frame. The model's body is turned about thirty degrees from camera with the head returning to lens, one hand resting easily at the side or in a pocket, shoulders relaxed and open. Calm cream plaster wall with soft daylight falloff across it.",
+  },
+  {
+    name: "In motion",
+    body: "Full-length walking frame. The model steps naturally toward camera mid-stride, the garment carrying real motion in its fabric and hem, arms swinging loosely, gaze forward. Warm beige studio backdrop kept quiet so the movement of the cloth reads clearly.",
+  },
+];
+
+function toConcept(shot: Shot, palette: string[]): CreativeConcept {
+  const empty = { eyebrow: null, headline: "", subhead: null, cta: "" };
+  return {
+    name: shot.name,
+    bigIdea: shot.body,
+    whyFits: "E-commerce apparel product-page shot.",
+    insightRationale: "",
+    artDirection: shot.body,
+    archetype: "headline_bottom",
+    productPlacement: "lifestyle",
+    sceneDescription: shot.body,
+    imagePrompt: shot.body,
+    typographySpec: "",
+    paletteHexes: palette.length ? palette.slice(0, 4) : ["#f5f1ea", "#d8cfc2"],
+    copy: { en: empty, hinglish: empty, hi: empty, pa: empty },
+  } as CreativeConcept;
+}
+
+export function buildCatalogConcepts(opts: {
+  count: number;
+  poseDriven?: boolean;
+  palette?: string[];
+}): CreativeConcept[] {
+  const palette = opts.palette ?? [];
+  const n = Math.max(1, opts.count);
+  return Array.from({ length: n }, (_, i) => toConcept(SHOTS[i % SHOTS.length], palette));
+}

--- a/src/lib/pipeline/catalog-concepts.ts
+++ b/src/lib/pipeline/catalog-concepts.ts
@@ -53,6 +53,13 @@ const SHOTS: Shot[] = [
   },
 ];
 
+/** Pose-driven runs get the pose from the run itself, so the body must not
+ * dictate a competing one — it sets the backdrop and camera only. */
+const NEUTRAL_SHOT: Shot = {
+  name: "Studio shot",
+  body: "Full-length studio frame on a warm off-white seamless backdrop with a soft floor gradient and a gentle contact shadow. Camera at chest height, straight and undistorted, the full figure centred with the garment reading clearly from head to hem.",
+};
+
 function toConcept(shot: Shot, palette: string[]): CreativeConcept {
   const empty = { eyebrow: null, headline: "", subhead: null, cta: "" };
   return {
@@ -71,12 +78,18 @@ function toConcept(shot: Shot, palette: string[]): CreativeConcept {
   } as CreativeConcept;
 }
 
+/**
+ * Build `count` catalog shot briefs. Pose-driven runs (the user picked poses in
+ * the studio) always get exactly one neutral brief — there the poses are the
+ * variation axis and the caller renders one creative per pose.
+ */
 export function buildCatalogConcepts(opts: {
   count: number;
   poseDriven?: boolean;
   palette?: string[];
 }): CreativeConcept[] {
   const palette = opts.palette ?? [];
+  if (opts.poseDriven) return [toConcept(NEUTRAL_SHOT, palette)];
   const n = Math.max(1, opts.count);
   return Array.from({ length: n }, (_, i) => toConcept(SHOTS[i % SHOTS.length], palette));
 }

--- a/src/lib/pipeline/model-qa.ts
+++ b/src/lib/pipeline/model-qa.ts
@@ -20,7 +20,9 @@ const verdictSchema = z.object({
     .describe("Does the model's face and overall identity (gender, age range, skin tone, build, hair) clearly match the MODEL reference photo? Noticeable face drift or a different-looking person = false."),
   garmentFaithful: z
     .boolean()
-    .describe("Does the worn garment match the GARMENT reference photo — same colour, print/pattern, neckline, sleeves, length and cut? Restyled, recoloured or redesigned = false."),
+    .describe(
+      "Does the worn garment match the GARMENT reference photo — same colour, print/pattern, neckline, sleeve length, HEM LENGTH and cut? Judge the hem strictly: a hip- or knee-length tunic rendered as an ankle-length gown (or the reverse) is false, as is invented embellishment (beading, appliqué, borders) the reference does not have.",
+    ),
   singleFigure: z
     .boolean()
     .describe("Is there exactly ONE figure in ONE single photograph (no front/back split, no side-by-side panels, no repeated or mirrored figure, no collage)?"),

--- a/src/lib/pipeline/model-qa.ts
+++ b/src/lib/pipeline/model-qa.ts
@@ -56,7 +56,7 @@ export async function checkOnModelFidelity(opts: {
             { type: "image", image: opts.render },
             {
               type: "text",
-              text: "Judge the generated image against both references. Identity: same person as the MODEL reference (face, gender, age range, skin tone, build)? Garment: same clothing as the GARMENT reference (colour, print, cut, neckline, sleeves, length)? Composition: exactly one figure, one single photograph? Ignore background, lighting style and pose differences — those are allowed to vary.",
+              text: "Judge the generated image against both references. Identity: same person as the MODEL reference (face, gender, age range, skin tone, build)? Garment: same clothing as the GARMENT reference — colour, print, cut, neckline, sleeve length, where the HEM falls on the body, and no invented embellishment? Composition: exactly one figure, one single photograph? Ignore background, lighting style and pose differences — those are allowed to vary. The garment reference may be shown on a hanger or a mannequin; judge the garment itself, not how it is displayed.",
             },
           ],
         },

--- a/src/lib/pipeline/typography.ts
+++ b/src/lib/pipeline/typography.ts
@@ -18,6 +18,9 @@ export async function applyTypographyPass(opts: {
   typographySpec?: string | null;
   paletteHexes?: string[];
   aspect: SceneAspect;
+  /** Image-model params (the workspace's pinned model, soft-prefer). Omitted =
+   * the default quality-first cascade. */
+  model?: Pick<Parameters<typeof generateScene>[0], "provider" | "tier" | "softPrefer" | "runwareModel">;
   tracker?: CostTracker;
 }): Promise<{ plate: Buffer; ok: boolean; issues?: string }> {
   for (let attempt = 0; attempt < 2; attempt++) {
@@ -32,6 +35,7 @@ export async function applyTypographyPass(opts: {
       prompt,
       aspect: opts.aspect,
       references: [{ buffer: opts.scenePlate, mime: "image/png" }],
+      ...opts.model,
     });
     opts.tracker?.addImage(gen.costModel, "typography");
     const qa = await checkBakedText({

--- a/src/lib/run-heal.ts
+++ b/src/lib/run-heal.ts
@@ -48,3 +48,18 @@ export async function healStalledRun(runId: string): Promise<GenerationStatus | 
   }
   return nextStatus;
 }
+
+/** Sweep every stalled run. Used by the scheduled healer so recovery never
+ * depends on a user opening the studio page for that specific run. */
+export async function healAllStalledRuns(): Promise<{ healed: number; runIds: string[] }> {
+  const stalled = await prisma.generationRun.findMany({
+    where: { status: { notIn: TERMINAL }, startedAt: { lt: new Date(Date.now() - RUN_STALL_MS) } },
+    select: { id: true },
+    take: 100,
+  });
+  const runIds: string[] = [];
+  for (const { id } of stalled) {
+    if (await healStalledRun(id)) runIds.push(id);
+  }
+  return { healed: runIds.length, runIds };
+}

--- a/src/lib/run-heal.ts
+++ b/src/lib/run-heal.ts
@@ -1,0 +1,50 @@
+import { prisma } from "@/lib/db";
+import { CREDIT_COSTS } from "@/lib/ai/models";
+import { reconcileRunRefund } from "@/lib/credits";
+import type { GenerationStatus } from "@/generated/prisma/client";
+
+/**
+ * Recovery for runs whose worker died without running catchError — an OOM kill
+ * or a hard crash kills the process, so the task's own error handling never
+ * executes and the row sits non-terminal forever (spinner in the studio, credits
+ * held). generation-run's maxDuration is 900s, so anything still non-terminal
+ * well past that is definitively dead.
+ */
+const TERMINAL: GenerationStatus[] = ["COMPLETE", "PARTIAL", "FAILED"];
+export const RUN_STALL_MS = Number(process.env.RUN_STALL_MS ?? 20 * 60 * 1000);
+
+/**
+ * Fail a stalled run and refund what it never delivered. Idempotent and
+ * race-safe: the status flip is conditional (only one caller wins) and the
+ * refund is reconciled against prior refunds for the same run, so the page
+ * render, the scheduled sweep and a concurrent tab can all call this freely.
+ * Returns the new status, or null when the run is healthy / already terminal.
+ */
+export async function healStalledRun(runId: string): Promise<GenerationStatus | null> {
+  const run = await prisma.generationRun.findUnique({
+    where: { id: runId },
+    select: { id: true, workspaceId: true, status: true, startedAt: true, creditsDebited: true },
+  });
+  if (!run || TERMINAL.includes(run.status)) return null;
+  if (Date.now() - run.startedAt.getTime() < RUN_STALL_MS) return null;
+
+  const delivered = await prisma.creative.count({ where: { generationRunId: run.id, status: "READY" } });
+  const nextStatus: GenerationStatus = delivered > 0 ? "PARTIAL" : "FAILED";
+  const flipped = await prisma.generationRun.updateMany({
+    where: { id: run.id, status: { notIn: TERMINAL } },
+    data: {
+      status: nextStatus,
+      finishedAt: new Date(),
+      error: "Run stalled (worker lost) — auto-failed",
+    },
+  });
+  if (flipped.count > 0 && Number(run.creditsDebited) > 0) {
+    await reconcileRunRefund({
+      workspaceId: run.workspaceId,
+      generationRunId: run.id,
+      owedRefund: Number(run.creditsDebited) - delivered * CREDIT_COSTS.perConcept,
+      note: "Run stalled — automatic refund",
+    });
+  }
+  return nextStatus;
+}

--- a/src/trigger/creative-edit.ts
+++ b/src/trigger/creative-edit.ts
@@ -35,6 +35,9 @@ export type CreativeEditPayload =
 export const creativeEdit = task({
   id: "creative-edit",
   maxDuration: 300,
+  // Decodes a full-size plate, re-composites it and can call an image model —
+  // the 0.5 GB default preset is not enough headroom (see generation-run).
+  machine: { preset: "medium-1x" }, // 1 vCPU / 2 GB
   retry: { maxAttempts: 1 }, // a retry would re-spend the image call after a refund
   run: async (payload: CreativeEditPayload) => {
     metadata.set("status", "editing");

--- a/src/trigger/generation-run.ts
+++ b/src/trigger/generation-run.ts
@@ -73,6 +73,14 @@ type RunWithRels = Awaited<ReturnType<typeof loadRun>>;
 export const generationRun = task({
   id: "generation-run",
   maxDuration: 900,
+  // The default preset is small-1x = 0.5 GB, and this task holds several
+  // multi-megapixel PNGs in memory at once per concurrent concept (plate +
+  // composited render + sharp raster + base64 copies of three images for the
+  // fidelity QA call), times maxConcurrentConcepts. That OOM-killed a 3-pose
+  // 9:16 production run mid-render — and an OOM kill is a process kill, so
+  // catchError never ran and the run sat non-terminal.
+  machine: { preset: "medium-2x" }, // 2 vCPU / 4 GB
+
   retry: { maxAttempts: 1 }, // per-concept isolation inside; whole-run retry would double-bill
   run: async (payload: { runId: string }) => {
     const { runId } = payload;

--- a/src/trigger/generation-run.ts
+++ b/src/trigger/generation-run.ts
@@ -5,8 +5,8 @@ import { generateScene, variantsForPref, resolveWorkspaceImageModel, BAKEOFF_VAR
 import { downloadFromStorage, storageKeys, uploadBuffer } from "@/lib/storage";
 import { reconcileRunRefund } from "@/lib/credits";
 import { assembleOccasionBrief } from "@/lib/pipeline/brief";
-import { buildCatalogConcepts } from "@/lib/pipeline/catalog-concepts";
 import { generateConcepts } from "@/lib/pipeline/concepts";
+import { buildCatalogConcepts } from "@/lib/pipeline/catalog-concepts";
 import { validateAndRepairConcepts, enhanceConceptPrompts } from "@/lib/pipeline/validate-concepts";
 import { intelToEvidenceBlock, type BrandIntel } from "@/lib/pipeline/brand-intel";
 import type { brandResearch } from "./brand-research";
@@ -141,11 +141,19 @@ export const generationRun = task({
     const onModelDirection: OnModelDirection =
       workspace?.type === "FASHION_EDITORIAL" ? "editorial" : "catalog";
 
+    // Lite path: a PLAIN on-model run ships the bare model+garment photograph
+    // (no headline, CTA or logo is ever composited), so the concept LLM stack
+    // authored copy and art direction that were thrown away. These runs skip
+    // concepting/brief-QA/enhancement entirely and render deterministic catalog
+    // shot briefs instead — see catalog-concepts.ts.
+    const litePlain = onModel && run.brandingMode === "PLAIN";
+
     const ctx: ConceptCtx = {
       runId, run, refBuffer, refMime, extraRefs, logoBuffer, logoAssetKey: logoAsset?.storageKey,
       aspects, masterAspect, language, intel, studioComposite, tracker,
       onModel, modelBuffer, modelMime: run.aiModel?.mimeType ?? "image/png",
       onModelDirection,
+      qaRetries: litePlain ? LITE_QA_MAX_RETRIES : PACK_QA_MAX_RETRIES,
       variantTag: "",
     };
 
@@ -209,7 +217,9 @@ export const generationRun = task({
       const brandIntel = (run.brand.creativeIntel as BrandIntel | null) ?? null;
       const intelAgeMs = run.brand.creativeIntelAt ? Date.now() - run.brand.creativeIntelAt.getTime() : Infinity;
       const STALE_MS = Number(process.env.BRAND_INTEL_STALE_MS ?? 1000 * 60 * 60 * 24 * 30);
-      if (!brandIntel || intelAgeMs > STALE_MS) {
+      // Lite runs never read brand intel, so they don't pay to refresh it — a
+      // branded run on the same brand will kick the research off when it needs it.
+      if (!litePlain && (!brandIntel || intelAgeMs > STALE_MS)) {
         try {
           await tasks.trigger<typeof brandResearch>("brand-research", { brandId: run.brandId });
         } catch (e) {
@@ -225,37 +235,48 @@ export const generationRun = task({
       // Every other run generates one concept per requested option.
       const multiPose = onModel && run.modelPoses.length > 0;
       const conceptTarget = multiPose ? 1 : Math.min(run.conceptCount, LIMITS.maxConceptsPerRun);
-      let concepts = await generateConcepts(
-        occasionBrief,
-        conceptTarget,
-        tracker,
-        brandPalette.length ? brandPalette : undefined,
-        intelToEvidenceBlock(brandIntel),
-        { exactProduct: ctx.studioComposite, onModelPlain: onModel && run.brandingMode === "PLAIN" },
-      );
+      let concepts: CreativeConcept[];
+      if (litePlain) {
+        // Deterministic catalog shot briefs — no concepting, no brief QA, no
+        // enhancer (their output is discarded on this path; see the module).
+        concepts = buildCatalogConcepts({ count: conceptTarget, poseDriven: multiPose, palette: brandPalette });
+        logger.info("lite path: deterministic catalog briefs", { concepts: concepts.length, poseDriven: multiPose });
+        await updatePipeline(runId, (p) => {
+          (p as PipelineState & { lite?: string }).lite = "plain-on-model";
+        });
+      } else {
+        concepts = await generateConcepts(
+          occasionBrief,
+          conceptTarget,
+          tracker,
+          brandPalette.length ? brandPalette : undefined,
+          intelToEvidenceBlock(brandIntel),
+          { exactProduct: ctx.studioComposite, onModelPlain: onModel && run.brandingMode === "PLAIN" },
+        );
 
-      // ---- Stage 2b: semantic brief QA + repair, then photographic prompt
-      // polish — both BEFORE any image spend. Fail-open: a QA/enhancer outage
-      // renders the authored concepts unchanged (never kills a paid run).
-      try {
-        const { concepts: validated, report } = await validateAndRepairConcepts({ concepts, occasionBrief, tracker });
-        concepts = validated;
-        await updatePipeline(runId, (p) => { (p as PipelineState & { briefQa?: typeof report }).briefQa = report; });
-        if (report.flagged) logger.warn("brief QA flagged concepts", { flagged: report.flagged, repaired: report.repaired, issues: report.issues });
-      } catch (e) {
-        logger.warn("brief QA unavailable — rendering authored concepts", { error: (e as Error).message });
-        // Marker write must never outrank the run it describes (fail-open²).
-        await updatePipeline(runId, (p) => {
-          ((p as PipelineState & { degraded?: string[] }).degraded ??= []).push("brief-qa-skipped");
-        }).catch(() => {});
-      }
-      try {
-        concepts = await enhanceConceptPrompts({ concepts, tracker });
-      } catch (e) {
-        logger.warn("prompt enhancer unavailable — rendering authored prompts", { error: (e as Error).message });
-        await updatePipeline(runId, (p) => {
-          ((p as PipelineState & { degraded?: string[] }).degraded ??= []).push("enhancer-skipped");
-        }).catch(() => {});
+        // ---- Stage 2b: semantic brief QA + repair, then photographic prompt
+        // polish — both BEFORE any image spend. Fail-open: a QA/enhancer outage
+        // renders the authored concepts unchanged (never kills a paid run).
+        try {
+          const { concepts: validated, report } = await validateAndRepairConcepts({ concepts, occasionBrief, tracker });
+          concepts = validated;
+          await updatePipeline(runId, (p) => { (p as PipelineState & { briefQa?: typeof report }).briefQa = report; });
+          if (report.flagged) logger.warn("brief QA flagged concepts", { flagged: report.flagged, repaired: report.repaired, issues: report.issues });
+        } catch (e) {
+          logger.warn("brief QA unavailable — rendering authored concepts", { error: (e as Error).message });
+          // Marker write must never outrank the run it describes (fail-open²).
+          await updatePipeline(runId, (p) => {
+            ((p as PipelineState & { degraded?: string[] }).degraded ??= []).push("brief-qa-skipped");
+          }).catch(() => {});
+        }
+        try {
+          concepts = await enhanceConceptPrompts({ concepts, tracker });
+        } catch (e) {
+          logger.warn("prompt enhancer unavailable — rendering authored prompts", { error: (e as Error).message });
+          await updatePipeline(runId, (p) => {
+            ((p as PipelineState & { degraded?: string[] }).degraded ??= []).push("enhancer-skipped");
+          }).catch(() => {});
+        }
       }
 
       // Work items. Normal runs: one per concept, times the variant lineup on
@@ -400,6 +421,8 @@ interface ConceptCtx {
   modelMime: string;
   /** Photoshoot treatment for ON_MODEL renders, resolved from the workspace type. */
   onModelDirection: OnModelDirection;
+  /** Corrective re-render budget for fidelity QA on this run. */
+  qaRetries: number;
   tracker: CostTracker;
   /** Bake-off / model pick: render on this variant. `soft` keeps the fallback
    * chain behind the preferred provider (user picks); bake-off never falls back. */
@@ -506,6 +529,10 @@ async function generatePlate(ctx: ConceptCtx, concept: CreativeConcept, aspect: 
  * env-tunable). Keeps the last attempt either way; the verdict rides along
  * for human review. */
 const PACK_QA_MAX_RETRIES = Number(process.env.PACK_QA_MAX_RETRIES ?? 2);
+/** Lite (PLAIN on-model) budget. A corrective re-render costs a full image;
+ * on a bulk catalog drop the second one rarely changes the verdict, so this
+ * path trades the long tail for predictable unit cost. */
+const LITE_QA_MAX_RETRIES = Number(process.env.LITE_QA_MAX_RETRIES ?? 1);
 async function ensurePackFidelity(
   ctx: ConceptCtx,
   opts: {
@@ -520,8 +547,8 @@ async function ensurePackFidelity(
   let gen = opts.gen;
   let verdict = await checkPackFidelity({ render: gen.buffer, reference: ctx.refBuffer!, tracker: ctx.tracker });
   let retried = false;
-  for (let attempt = 1; attempt <= PACK_QA_MAX_RETRIES && !verdict.pass; attempt++) {
-    logger.warn("pack fidelity failed, re-rendering", { attempt, of: PACK_QA_MAX_RETRIES, issues: verdict.issues });
+  for (let attempt = 1; attempt <= ctx.qaRetries && !verdict.pass; attempt++) {
+    logger.warn("pack fidelity failed, re-rendering", { attempt, of: ctx.qaRetries, issues: verdict.issues });
     const strictPrompt = `${opts.prompt}\n\nCRITICAL CORRECTION: a previous render altered the product's packaging (${verdict.issues}). Reproduce the reference pack EXACTLY — every word of label text spelled identically, same colours, same logo, same layout. Do not restyle or reinterpret the packaging in any way.`;
     gen = await generateScene({
       prompt: strictPrompt,
@@ -559,8 +586,8 @@ async function ensureOnModelFidelity(
   let gen = opts.gen;
   let verdict = await check(gen.buffer);
   let retried = false;
-  for (let attempt = 1; attempt <= PACK_QA_MAX_RETRIES && !verdict.pass; attempt++) {
-    logger.warn("on-model fidelity failed, re-rendering", { attempt, of: PACK_QA_MAX_RETRIES, issues: verdict.issues });
+  for (let attempt = 1; attempt <= ctx.qaRetries && !verdict.pass; attempt++) {
+    logger.warn("on-model fidelity failed, re-rendering", { attempt, of: ctx.qaRetries, issues: verdict.issues });
     const strictPrompt = `${opts.prompt}\n\nCRITICAL CORRECTION: a previous render drifted from the references (${verdict.issues}). The model MUST be the exact person from IMAGE 1 (same face, gender, age, skin tone, build, hair) and the garment MUST be the exact clothing from IMAGE 2 (same colour, print, cut, neckline, sleeves, length) — one single figure in one single photograph.`;
     gen = await generateScene({
       prompt: strictPrompt,
@@ -794,7 +821,9 @@ async function composeAllAspects(
         await prisma.creativeRender.create({
           data: { creativeId, aspectRatio: aspect, overlaySpec: spec as unknown as Prisma.InputJsonValue, composedImageKey: key, status: "COMPOSED" },
         });
-        critics[aspect] = { chosen: "plain", brandingMode: "PLAIN" };
+        // Carry the fidelity verdict even here — PLAIN on-model is the highest
+        // volume path, so its identity/garment QA outcome must be measurable.
+        critics[aspect] = { chosen: "plain", brandingMode: "PLAIN", packQa: layout.plateQa?.[aspect] };
         return { spec, key, aspect };
       }
 

--- a/src/trigger/generation-run.ts
+++ b/src/trigger/generation-run.ts
@@ -5,6 +5,7 @@ import { generateScene, variantsForPref, resolveWorkspaceImageModel, BAKEOFF_VAR
 import { downloadFromStorage, storageKeys, uploadBuffer } from "@/lib/storage";
 import { reconcileRunRefund } from "@/lib/credits";
 import { assembleOccasionBrief } from "@/lib/pipeline/brief";
+import { buildCatalogConcepts } from "@/lib/pipeline/catalog-concepts";
 import { generateConcepts } from "@/lib/pipeline/concepts";
 import { validateAndRepairConcepts, enhanceConceptPrompts } from "@/lib/pipeline/validate-concepts";
 import { intelToEvidenceBlock, type BrandIntel } from "@/lib/pipeline/brand-intel";

--- a/src/trigger/heal-runs.ts
+++ b/src/trigger/heal-runs.ts
@@ -1,0 +1,18 @@
+import { schedules, logger } from "@trigger.dev/sdk";
+import { healAllStalledRuns } from "@/lib/run-heal";
+
+/**
+ * Sweep runs whose worker died (OOM kill, crash) and left them non-terminal.
+ * The studio page heals the run it is showing, but only while someone is
+ * looking at it — a user who closed the tab kept a spinner and held credits
+ * until they came back. This runs every 10 minutes regardless.
+ */
+export const healRuns = schedules.task({
+  id: "heal-stalled-runs",
+  cron: "*/10 * * * *",
+  run: async () => {
+    const { healed, runIds } = await healAllStalledRuns();
+    if (healed > 0) logger.warn("healed stalled runs", { healed, runIds });
+    return { healed };
+  },
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,3 +6,17 @@ Worst real PLAIN on-model run = **$0.524 / creative**: on-model renders $0.402 (
 $0.134 × 3 — 1 render + 2 fidelity retries), concepts (Opus) $0.085, enhancer $0.020,
 brief-QA $0.013, model-QA $0.004. Client wants ≤ $0.5 charge for 800+ images.
 The concept stack's output is discarded on this path — PLAIN composites no text or logo.
+
+## Decisions (My Lord)
+- Lite path gated on `ON_MODEL + PLAIN` (not on account type wholesale).
+- Run a real bake-off before pinning a cheaper image model.
+
+## Plan
+- [ ] `src/lib/pipeline/catalog-concepts.ts` — deterministic shot briefs
+- [ ] generation-run: lite branch skips concepts / brief-QA / enhancer
+- [ ] fidelity-QA retry budget per path
+- [ ] persist the fidelity verdict for PLAIN creatives
+- [ ] workspace image-model pin honoured in the editor paths
+- [ ] fix: Runware rejected our 4500-char on-model prompt
+- [ ] bake-off: 4 garments × 4 models
+- [ ] DEVLOG entry

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,11 +12,19 @@ The concept stack's output is discarded on this path — PLAIN composites no tex
 - Run a real bake-off before pinning a cheaper image model.
 
 ## Plan
-- [ ] `src/lib/pipeline/catalog-concepts.ts` — deterministic shot briefs
-- [ ] generation-run: lite branch skips concepts / brief-QA / enhancer
-- [ ] fidelity-QA retry budget per path
-- [ ] persist the fidelity verdict for PLAIN creatives
-- [ ] workspace image-model pin honoured in the editor paths
-- [ ] fix: Runware rejected our 4500-char on-model prompt
-- [ ] bake-off: 4 garments × 4 models
+- [x] `src/lib/pipeline/catalog-concepts.ts` — deterministic shot briefs (6-shot table + neutral pose-driven brief)
+- [x] generation-run: lite branch skips concepts / brief-QA / enhancer / brand-research refresh
+- [x] fidelity-QA retry budget per path (`LITE_QA_MAX_RETRIES`, default 1 vs 2)
+- [x] persist the fidelity verdict for PLAIN creatives (was invisible on the highest-volume path)
+- [x] tests: catalog-concepts (3) + runware prompt fit (2)
+- [x] admin costs list: "Spend by pipeline stage · last 30 days" + clickable run rows
+- [x] e2e: `PACK_QA_MAX_RETRIES=0` / `LITE_QA_MAX_RETRIES=0` (retries were the suite's biggest line)
+- [x] workspace image-model pin honoured in the editor paths (was silently NB Pro)
+- [x] fix: Runware rejected our 4500-char on-model prompt → every Seedream/Qwen/Wan on-model render failed
+- [ ] bake-off: 4 garments × 4 models, judge fidelity, recommend the pin
 - [ ] DEVLOG entry
+
+## Open for My Lord
+- "Compare" pref + a workspace pin = 2× credits debited, 1 render delivered (generate.ts:149 vs
+  generation-run.ts:147). Needs a decision: pin wins, pref wins, or refund the unused variant.
+- `generate-model.ts` renders AI models on NB Pro ($0.134) — one-time per model, cheap to downgrade.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,26 +1,8 @@
-# 2026-07-23 — workspace account types (FMCG / e-com apparel / premium fashion)
-(prev round archived: tasks/todo-r4-archive.md; plan: ~/.ccpm/profiles/work/plans/warm-singing-comet.md)
+# 2026-07-25 — cost reduction for the e-commerce apparel path
+(prev round archived in git history; account-types feature shipped 2026-07-23)
 
-## Decisions (from My Lord)
-- 3 segments = existing WorkspaceType enum (no migration). References: schein.in (e-com apparel), theblueman.net (premium fashion).
-- Settings: owner/admin (canManage) editable. Onboarding: 3-card picker REPLACES industry+usecase selects (keep salesChannel).
-
-## Plan
-- [x] src/lib/workspace-type.ts — shared WORKSPACE_TYPES metadata (client-safe)
-- [x] src/components/account-type-picker.tsx — shared radio-card picker
-- [x] admin new-workspace-dialog → use shared picker/metadata
-- [x] onboarding wizard: ProfileFields → AccountTypePicker (required) + salesChannel only
-- [x] brand.ts saveWorkspaceProfile: persist workspace.type + salesChannel; stop writing industry/useCase
-- [x] workspace-profile.ts showsModelSurface: type-first, legacy profile fallback (callers unchanged — profile carries type)
-- [x] workspace.ts setWorkspaceType (requireManager) + settings card (read-only for non-managers)
-- [x] image-prompt.ts: rewrite ON_MODEL_DIRECTION catalog (schein) + editorial (blueman)
-- [x] generation-run.ts: 3-way ACCOUNT STYLE brief block (FMCG none / APPAREL catalog / EDITORIAL campaign)
-- [x] tests: showsModelSurface matrix + updated direction-string assertions
-- [x] verify: tsc ✓ lint ✓ vitest 65 ✓; prod type audit done; DEVLOG entry written
-
-## Review — DONE
-- All UI reuses one AccountTypePicker (admin dialog, onboarding, settings). Zero DB migrations.
-- Live smoke: settings picker persists to DB + toast + revert works (dev workspace flipped APPAREL_ON_MODEL→back); onboarding renders 3-card picker, required radio blocks submit.
-- Concept + render prompts now 3-way: FMCG unchanged; APPAREL_ON_MODEL = schein-anchored (soft diffused light, warm beige architectural sets, garment hero); FASHION_EDITORIAL = blueman-anchored (styled character, environmental depth, rim light, rich grade).
-- FLAGS for My Lord: (1) prod workspaces "Synerix Apparel" + "E2E Tests" are typed FMCG_PRODUCT but are apparel — fix via new settings card. (2) Pre-existing: image-model Select shows raw "__default__" instead of its label. (3) dev:next left running on :6969 for your testing.
-- UNCOMMITTED — My Lord tests, then commit via retroactive-commit-history.
+## Problem (measured, prod ApiCostLog)
+Worst real PLAIN on-model run = **$0.524 / creative**: on-model renders $0.402 (NB Pro
+$0.134 × 3 — 1 render + 2 fidelity retries), concepts (Opus) $0.085, enhancer $0.020,
+brief-QA $0.013, model-QA $0.004. Client wants ≤ $0.5 charge for 800+ images.
+The concept stack's output is discarded on this path — PLAIN composites no text or logo.


### PR DESCRIPTION
## Summary
- Cut PLAIN on-model unit cost by skipping discarded concepting/QA/enhancer work in favor of deterministic catalog shot briefs, with a lower fidelity-retry budget.
- Recover OOM/crash-killed runs: medium-2x machine preset, shared `healStalledRun` + 10-minute scheduled sweep, and studio UI that treats dead Trigger runs as terminal.
- Honour workspace image-model pins in paid editor paths; fix Runware prompt length rejections; tighten on-model garment QA; add admin stage-spend breakdown; disable fidelity re-renders in e2e.

## Test plan
- [ ] CI green (lint/typecheck/unit + e2e gates)
- [ ] PLAIN on-model run shows `lite="plain-on-model"` and near-zero concepting spend
- [ ] Branded / non-PLAIN runs still concept + brief-QA as before
- [ ] Studio shows failure (not infinite spinner) when a Trigger run crashes; credits refund after heal
- [ ] Workspace pinned to a cheap model is used for editor regen / baked-text (not silent NB Pro)
- [ ] Admin `/admin/costs` shows stage breakdown + clickable run rows